### PR TITLE
fix:Invalid cache for user likes

### DIFF
--- a/src/controllers/homeFeed.controllers.js
+++ b/src/controllers/homeFeed.controllers.js
@@ -8,7 +8,7 @@ import { asyncHandler } from '../utlis/asyncHandler.js';
 import Like from '../models/like.models.js';
 import PostInteraction from '../models/postInteraction.models.js';
 import { setCache } from '../middlewares/cache.middleware.js';
-import { redisClient } from '../config/redis.config.js';
+import { redisClient, RedisKeys, RedisTTL } from '../config/redis.config.js';
 import { getViewableUserIds } from '../middlewares/privacy.middleware.js';
 import { bulkCheckActivePaymentPlans } from '../utlis/businessPlan.utils.js';
 import mongoose from 'mongoose';
@@ -49,13 +49,23 @@ export const getHomeFeed = asyncHandler(async (req, res) => {
         console.log('🔍 Feed Debug - userId:', userId);
         console.log('🔍 Feed Debug - blockedUsers count:', blockedUsers.length);
 
-        // Check cache first
-        if (res.locals.cacheKey) {
-            const cachedData = await redisClient.get(res.locals.cacheKey);
-            if (cachedData) {
-                console.log('📦 Returning cached feed');
-                return res.status(200).json(JSON.parse(cachedData));
+        // Check cache first — isLikedBy is never stored in cache, always computed fresh
+        const FEED_CACHE_KEY = RedisKeys.userFeed(userId, page);
+        const cachedRaw = await redisClient.get(FEED_CACHE_KEY);
+        if (cachedRaw) {
+            console.log('📦 Returning cached feed');
+            const cached = JSON.parse(cachedRaw);
+            if (userId && cached?.data?.feed?.length) {
+                const cachedPostIds = cached.data.feed.map(p => p._id);
+                const userLikes = await Like.find({ userId, postId: { $in: cachedPostIds } })
+                    .select('postId').lean();
+                const likedSet = new Set(userLikes.map(l => l.postId.toString()));
+                cached.data.feed = cached.data.feed.map(post => ({
+                    ...post,
+                    isLikedBy: likedSet.has(post._id.toString())
+                }));
             }
+            return res.status(200).json(cached);
         }
 
         const FEED_LIMIT = 50; // Reduced from 100
@@ -425,10 +435,13 @@ export const getHomeFeed = asyncHandler(async (req, res) => {
             }
         }, "Home feed generated successfully");
 
-        // Cache the response
-        if (res.locals.cacheKey && res.locals.cacheTTL) {
-            await setCache(res.locals.cacheKey, response, res.locals.cacheTTL);
-        }
+        // Cache WITHOUT isLikedBy — it's always computed fresh to avoid stale heart state
+        const feedToCache = feedDataWithBadges.map(({ isLikedBy, ...rest }) => rest);
+        const responseToCache = new ApiResponse(200, {
+            feed: feedToCache,
+            pagination: { page, limit, total: totalCount, totalPages: Math.ceil(totalCount / limit) }
+        }, "Home feed generated successfully");
+        await setCache(FEED_CACHE_KEY, responseToCache, RedisTTL.USER_FEED);
 
         return res.status(200).json(response);
 

--- a/src/controllers/like.controllers.js
+++ b/src/controllers/like.controllers.js
@@ -6,6 +6,8 @@ import Post from "../models/userPost.models.js";
 import Comment from "../models/comment.models.js";
 import { createLikeNotification } from "./notification.controllers.js";
 import { createUnlikeNotification } from "./notification.controllers.js";
+import { invalidateCache } from "../middlewares/cache.middleware.js";
+import { RedisKeys } from "../config/redis.config.js";
 
 // Like a post
 export const likePost = asyncHandler(async (req, res) => {
@@ -16,6 +18,8 @@ export const likePost = asyncHandler(async (req, res) => {
     try {
         await Like.create({ userId, postId });
         await Post.findByIdAndUpdate(postId, { $inc: { "engagement.likes": 1 } });
+        // Invalidate user's feed cache so isLikedBy reflects the new like
+        await invalidateCache(`fn:user:${userId}:feed:*`);
 
         // Notify post owner (if not self) - with error handling
         try {
@@ -68,6 +72,8 @@ export const unlikePost = asyncHandler(async (req, res) => {
 
     // Decrement engagement count (MongoDB will handle defaults from schema)
     await Post.findByIdAndUpdate(postId, { $inc: { "engagement.likes": -1 } });
+    // Invalidate user's feed cache so isLikedBy reflects the unlike
+    await invalidateCache(`fn:user:${userId}:feed:*`);
 
     // Notify post owner (if not self) - with error handling
     try {

--- a/src/routes/post.routes.js
+++ b/src/routes/post.routes.js
@@ -57,7 +57,7 @@ const batchMediaUpload = upload.fields(
 router.route("/create/batch").post(batchMediaUpload, verifyJWT, createBatchPosts);
 router.route("/user/:userId/profile").get(verifyJWT, getUserProfilePosts);
 router.route("/switch/profile/:userId").get(verifyJWT, getProfileTabContent);
-router.route("/home-feed").get(optionalVerifyJWT, getBlockedUsersMiddleware, cacheUserFeed, getHomeFeed);
+router.route("/home-feed").get(optionalVerifyJWT, getBlockedUsersMiddleware, getHomeFeed);
 router.route("/myPosts").get(verifyJWT, getMyPosts);
 router.route("/notifications").get(verifyJWT, getNotifications);
 


### PR DESCRIPTION
- calculate the like status for post from db instead defending on stale cached data
- update only the like status while fetching the cached data from redis for user fetch request
- fix stale like status for user