### PR TITLE
feat: implement cache for follower,following count,user profile

### DIFF
--- a/src/config/redis.config.js
+++ b/src/config/redis.config.js
@@ -176,6 +176,40 @@ export const RedisKeys = {
     tokenBlacklist: (jti) => `fn:auth:blacklist:${jti}`,
     authRateLimit: (ip) => `fn:auth:rate:${ip}`,
     
+    // Follow counts (real-time counters, updated on every follow/unfollow)
+    userFollowersCount: (userId) => `fn:user:${userId}:followers:count`,
+    userFollowingCount: (userId) => `fn:user:${userId}:following:count`,
+
+    // Post engagement counters
+    postLikesCount: (postId) => `fn:post:${postId}:likes:count`,
+    postCommentsCount: (postId) => `fn:post:${postId}:comments:count`,
+
+    // Per-user like status (set on like, deleted/set-to-0 on unlike)
+    userLikedPost: (userId, postId) => `fn:like:${userId}:${postId}`,
+
+    // Universal default search page (no query — browse mode)
+    defaultResults: () => 'fn:default:results',
+    defaultNewPosts: () => 'fn:default:new_posts', // Redis LIST of recently published postIds
+
+    // Like dirty set — tracks unsync'd like/unlike ops; flushed to DB by 4-hourly cron
+    likesDirty: () => 'fn:likes:dirty',
+
+    // Per-user follow status: '1' = following, '0' = not following
+    userFollowStatus: (followerId, targetUserId) => `fn:follow:${followerId}:${targetUserId}`,
+
+    // Follow dirty set — tracks unsync'd follow/unfollow ops; flushed to DB by 4-hourly cron
+    followsDirty: () => 'fn:follows:dirty',
+
+    // Temp SETs of newly-added follower/following IDs not yet written to DB (flushed every 2h)
+    followersTemp: (userId) => `fn:user:${userId}:followers:temp`,
+    followingTemp: (userId) => `fn:user:${userId}:following:temp`,
+
+    // SET tracking which userIds have active temp keys (so the 2h cron knows who to flush)
+    followTempActiveUsers: () => 'fn:follows:temp:active',
+
+    // Cached liker userId array per post (JSON string, max 50); updated on like/unlike
+    postLikedBy: (postId) => `fn:post:${postId}:likedby`,
+
     // Real-time features
     chatMessages: (chatId, page = 1) => `fn:chat:${chatId}:messages:p${page}`,
     onlineUsers: () => 'fn:live:online_users',
@@ -206,6 +240,19 @@ export const RedisTTL = {
     TOKEN_BLACKLIST: 24 * 60 * 60,   // 24 hours
     RATE_LIMIT: 15 * 60,             // 15 minutes
     
+    // Follow counters (long-lived, updated in-place on follow/unfollow)
+    FOLLOW_COUNT: 7 * 24 * 60 * 60, // 7 days
+
+    // Post engagement counters + per-user like status
+    POST_ENGAGEMENT: 7 * 24 * 60 * 60, // 7 days
+    POST_LIKE_STATUS: 7 * 24 * 60 * 60, // 7 days
+
+    // Per-user follow status
+    FOLLOW_STATUS: 7 * 24 * 60 * 60, // 7 days
+
+    // Universal default search snapshot (safety TTL; explicit invalidation preferred)
+    DEFAULT_RESULTS: 24 * 60 * 60, // 24 hours
+
     // Temporary data
     TEMP_UPLOAD: 10 * 60,            // 10 minutes
     PASSWORD_RESET: 15 * 60,         // 15 minutes

--- a/src/controllers/follower.controllers.js
+++ b/src/controllers/follower.controllers.js
@@ -5,8 +5,23 @@ import { asyncHandler } from "../utlis/asyncHandler.js";
 import { ApiResponse } from "../utlis/ApiResponse.js";
 import { ApiError } from "../utlis/ApiError.js";
 import { createFollowNotification } from "./notification.controllers.js";
-import { redisClient } from "../config/redis.config.js";
+import { redisClient, RedisKeys } from "../config/redis.config.js";
 import { addBadgesToUsers } from "../utlis/userBadge.utils.js";
+import {
+    incrFollowersCount,
+    decrFollowersCount,
+    incrFollowingCount,
+    decrFollowingCount,
+    getFollowersCount,
+    getFollowingCount,
+} from "../utlis/followCount.utils.js";
+
+const MAX_FOLLOW_LIST = 15;
+import {
+    getFollowStatus,
+    onUserFollowed,
+    onUserUnfollowed,
+} from "../utlis/followEngagement.utils.js";
 
 // Follow a user (with privacy support)
 export const followUser = asyncHandler(async (req, res) => {
@@ -17,9 +32,9 @@ export const followUser = asyncHandler(async (req, res) => {
         throw new ApiError(400, "You cannot follow yourself");
     }
 
-    // Check if already following
-    const existingFollow = await Follower.findOne({ userId, followerId: requesterId });
-    if (existingFollow) throw new ApiError(400, "Already following");
+    // Check follow status: Redis first ('1'/'0'), DB fallback on miss or Redis down
+    const alreadyFollowing = await getFollowStatus(requesterId, userId);
+    if (alreadyFollowing) throw new ApiError(400, "Already following");
 
     // Check if there's ANY existing follow request (pending, rejected, or approved)
     const existingRequest = await FollowRequest.findOne({
@@ -43,22 +58,33 @@ export const followUser = asyncHandler(async (req, res) => {
             await FollowRequest.findByIdAndDelete(existingRequest._id);
         }
 
-        await Follower.create({ userId, followerId: requesterId });
+        // Try Redis-first (deferred DB write via 4-hourly cron)
+        const redisOk = await onUserFollowed(requesterId, userId);
 
-        // Update User model arrays
-        await User.findByIdAndUpdate(userId, { $addToSet: { followers: requesterId } });
-        await User.findByIdAndUpdate(requesterId, { $addToSet: { following: userId } });
+        if (!redisOk) {
+            // Redis is down — fall back to direct DB write
+            await Follower.create({ userId, followerId: requesterId });
+            await User.findByIdAndUpdate(userId, { $addToSet: { followers: requesterId } });
+            await User.findByIdAndUpdate(requesterId, { $addToSet: { following: userId } });
+        }
 
-        // Create notification
-        await createFollowNotification({ recipientId: userId, sourceUserId: requesterId });
-
-        // Invalidate caches
+        // Notification + cache invalidation fire-and-forget
+        createFollowNotification({ recipientId: userId, sourceUserId: requesterId }).catch(() => {});
         const { invalidateViewableUsersCache } = await import('../middlewares/privacy.middleware.js');
-        await invalidateViewableUsersCache(requesterId);
-        await invalidateViewableUsersCache(userId);
+        invalidateViewableUsersCache(requesterId).catch(() => {});
+        invalidateViewableUsersCache(userId).catch(() => {});
+        redisClient.del(`following:${requesterId}`).catch(() => {});
 
-        // Invalidate following cache
-        await redisClient.del(`following:${requesterId}`);
+        // Both count updates must succeed together — roll back if either fails
+        let newFollowersCount, newFollowingCount;
+        try {
+            newFollowersCount = await incrFollowersCount(userId.toString());
+            newFollowingCount = await incrFollowingCount(requesterId.toString());
+        } catch (err) {
+            // Compensate whichever succeeded
+            if (newFollowersCount !== undefined) decrFollowersCount(userId.toString()).catch(() => {});
+            throw new ApiError(500, 'Something went wrong while updating follow counts. Please try again.');
+        }
 
         return res.status(200).json(new ApiResponse(200, {
             followedUser: {
@@ -69,6 +95,8 @@ export const followUser = asyncHandler(async (req, res) => {
             },
             isFollowing: true,
             isPending: false,
+            followersCount: newFollowersCount ?? null,
+            followingCount: newFollowingCount ?? null,
             timestamp: new Date()
         }, "Followed successfully"));
     }
@@ -105,24 +133,38 @@ export const unfollowUser = asyncHandler(async (req, res) => {
     const requesterId = req.user._id;
     const { userId } = req.body; // userId to unfollow
 
-    // Check if currently following
-    const followRelation = await Follower.findOneAndDelete({ userId, followerId: requesterId });
+    // Check follow status: Redis first, DB fallback on miss or Redis down
+    const isFollowing = await getFollowStatus(requesterId, userId);
 
-    if (followRelation) {
-        // Update User model arrays
-        await User.findByIdAndUpdate(userId, { $pull: { followers: requesterId } });
-        await User.findByIdAndUpdate(requesterId, { $pull: { following: userId } });
+    if (isFollowing) {
+        // Try Redis-first (marks dirty for cron; also deletes Follower doc immediately)
+        const redisOk = await onUserUnfollowed(requesterId, userId);
 
-        // Get the unfollowed user's info to return in response
+        if (!redisOk) {
+            // Redis is down — fall back to direct DB write
+            await Follower.findOneAndDelete({ userId, followerId: requesterId });
+            await User.findByIdAndUpdate(userId, { $pull: { followers: requesterId } });
+            await User.findByIdAndUpdate(requesterId, { $pull: { following: userId } });
+        }
+
         const unfollowedUser = await User.findById(userId).select('username fullName profileImageUrl');
 
-        // Invalidate caches
+        // Cache invalidation fire-and-forget
         const { invalidateViewableUsersCache } = await import('../middlewares/privacy.middleware.js');
-        await invalidateViewableUsersCache(requesterId);
-        await invalidateViewableUsersCache(userId);
+        invalidateViewableUsersCache(requesterId).catch(() => {});
+        invalidateViewableUsersCache(userId).catch(() => {});
+        redisClient.del(`following:${requesterId}`).catch(() => {});
 
-        // Invalidate following cache
-        await redisClient.del(`following:${requesterId}`);
+        // Both count updates must succeed together — roll back if either fails
+        let newFollowersCount, newFollowingCount;
+        try {
+            newFollowersCount = await decrFollowersCount(userId.toString());
+            newFollowingCount = await decrFollowingCount(requesterId.toString());
+        } catch (err) {
+            // Compensate whichever succeeded
+            if (newFollowersCount !== undefined) incrFollowersCount(userId.toString()).catch(() => {});
+            throw new ApiError(500, 'Something went wrong while updating follow counts. Please try again.');
+        }
 
         return res.status(200).json(new ApiResponse(200, {
             unfollowedUser: {
@@ -133,15 +175,17 @@ export const unfollowUser = asyncHandler(async (req, res) => {
             },
             isFollowing: false,
             isPending: false,
+            followersCount: newFollowersCount ?? null,
+            followingCount: newFollowingCount ?? null,
             timestamp: new Date()
         }, "Unfollowed successfully"));
     }
 
     // Check if there's a pending follow request to cancel
-    const followRequest = await FollowRequest.findOneAndDelete({ 
-        requesterId, 
-        recipientId: userId, 
-        status: 'pending' 
+    const followRequest = await FollowRequest.findOneAndDelete({
+        requesterId,
+        recipientId: userId,
+        status: 'pending'
     });
 
     if (followRequest) {
@@ -163,28 +207,180 @@ export const unfollowUser = asyncHandler(async (req, res) => {
     throw new ApiError(400, "Not following this user and no pending request found");
 });
 
-// Get followers of a user
+// Get followers of a user (Redis-first, paginated)
 export const getFollowers = asyncHandler(async (req, res) => {
     const { userId } = req.params;
-    const followers = await Follower.find({ userId }).populate("followerId", "username profileImageUrl fullName isVerified bio isBusinessProfile");
-    const followerUsers = followers.map(f => f.followerId).filter(user => user !== null);
-    
-    // Add subscription badges
+    const page = Math.max(1, parseInt(req.query.page) || 1);
+    const limit = Math.min(50, Math.max(1, parseInt(req.query.limit) || 20));
+
+    // ── Total count from Redis (falls back to DB automatically) ──────────────
+    const totalCount = await getFollowersCount(userId);
+
+    // ── Build the unified cached ID list: temp SET union LIST, newest-first ──
+    let cachedIds = [];
+    try {
+        const [tempIds, listIds] = await Promise.all([
+            redisClient.smembers(RedisKeys.followersTemp(userId)),
+            redisClient.lrange(RedisKeys.userFollowers(userId), 0, MAX_FOLLOW_LIST - 1),
+        ]);
+        // Temp IDs first (most recent, not yet in DB), then list IDs, deduped
+        const seen = new Set();
+        for (const id of [...tempIds, ...listIds]) {
+            if (!seen.has(id)) { seen.add(id); cachedIds.push(id); }
+        }
+    } catch {
+        cachedIds = [];
+    }
+
+    let followerUsers = [];
+
+    if (page === 1) {
+        // Page 1: serve up to `limit` from cached IDs first, then fill from DB
+        const cachedSlice = cachedIds.slice(0, limit);
+        const fromCacheCount = cachedSlice.length;
+        const remainderNeeded = limit - fromCacheCount;
+
+        // Fetch cached users from User collection (preserves newest-first order)
+        let cachedUsers = [];
+        if (cachedSlice.length > 0) {
+            const userDocs = await User.find({ _id: { $in: cachedSlice } })
+                .select('username profileImageUrl fullName isVerified bio isBusinessProfile')
+                .lean();
+            // Re-sort to match cachedSlice order
+            const userMap = new Map(userDocs.map(u => [u._id.toString(), u]));
+            cachedUsers = cachedSlice.map(id => userMap.get(id)).filter(Boolean);
+        }
+
+        // Fill remainder from DB, excluding all cached IDs
+        let dbUsers = [];
+        if (remainderNeeded > 0) {
+            const dbFollowers = await Follower.find({
+                userId,
+                followerId: { $nin: cachedIds },
+            })
+                .sort({ createdAt: -1 })
+                .limit(remainderNeeded)
+                .populate('followerId', 'username profileImageUrl fullName isVerified bio isBusinessProfile')
+                .lean();
+            dbUsers = dbFollowers.map(f => f.followerId).filter(Boolean);
+        }
+
+        followerUsers = [...cachedUsers, ...dbUsers];
+    } else {
+        // Page 2+: all from DB, skip records already shown on page 1, exclude cached IDs
+        const page1Shown = Math.min(cachedIds.length, limit);
+        const dbAlreadyShownOnPage1 = limit - page1Shown; // how many DB records page 1 consumed
+        const dbSkip = dbAlreadyShownOnPage1 + (page - 2) * limit;
+
+        const dbFollowers = await Follower.find({
+            userId,
+            followerId: { $nin: cachedIds },
+        })
+            .sort({ createdAt: -1 })
+            .skip(dbSkip)
+            .limit(limit)
+            .populate('followerId', 'username profileImageUrl fullName isVerified bio isBusinessProfile')
+            .lean();
+
+        followerUsers = dbFollowers.map(f => f.followerId).filter(Boolean);
+    }
+
     const followersWithBadges = await addBadgesToUsers(followerUsers);
-    
-    res.status(200).json(new ApiResponse(200, followersWithBadges, "Followers fetched successfully"));
+    const hasMore = page * limit < totalCount;
+
+    res.status(200).json(new ApiResponse(200, {
+        followers: followersWithBadges,
+        totalCount,
+        page,
+        limit,
+        hasMore,
+    }, "Followers fetched successfully"));
 });
 
-// Get following of a user
+// Get following of a user (Redis-first, paginated)
 export const getFollowing = asyncHandler(async (req, res) => {
     const { userId } = req.params;
-    const following = await Follower.find({ followerId: userId }).populate("userId", "username profileImageUrl fullName isVerified bio isBusinessProfile");
-    const followingUsers = following.map(f => f.userId).filter(user => user !== null);
-    
-    // Add subscription badges
+    const page = Math.max(1, parseInt(req.query.page) || 1);
+    const limit = Math.min(50, Math.max(1, parseInt(req.query.limit) || 20));
+
+    // ── Total count from Redis (falls back to DB automatically) ──────────────
+    const totalCount = await getFollowingCount(userId);
+
+    // ── Build the unified cached ID list: temp SET union LIST, newest-first ──
+    let cachedIds = [];
+    try {
+        const [tempIds, listIds] = await Promise.all([
+            redisClient.smembers(RedisKeys.followingTemp(userId)),
+            redisClient.lrange(RedisKeys.userFollowing(userId), 0, MAX_FOLLOW_LIST - 1),
+        ]);
+        const seen = new Set();
+        for (const id of [...tempIds, ...listIds]) {
+            if (!seen.has(id)) { seen.add(id); cachedIds.push(id); }
+        }
+    } catch {
+        cachedIds = [];
+    }
+
+    let followingUsers = [];
+
+    if (page === 1) {
+        const cachedSlice = cachedIds.slice(0, limit);
+        const fromCacheCount = cachedSlice.length;
+        const remainderNeeded = limit - fromCacheCount;
+
+        // Fetch cached users from User collection
+        let cachedUsers = [];
+        if (cachedSlice.length > 0) {
+            const userDocs = await User.find({ _id: { $in: cachedSlice } })
+                .select('username profileImageUrl fullName isVerified bio isBusinessProfile')
+                .lean();
+            const userMap = new Map(userDocs.map(u => [u._id.toString(), u]));
+            cachedUsers = cachedSlice.map(id => userMap.get(id)).filter(Boolean);
+        }
+
+        // Fill remainder from DB — for following, the Follower record has followerId=userId
+        let dbUsers = [];
+        if (remainderNeeded > 0) {
+            const dbFollowing = await Follower.find({
+                followerId: userId,
+                userId: { $nin: cachedIds },
+            })
+                .sort({ createdAt: -1 })
+                .limit(remainderNeeded)
+                .populate('userId', 'username profileImageUrl fullName isVerified bio isBusinessProfile')
+                .lean();
+            dbUsers = dbFollowing.map(f => f.userId).filter(Boolean);
+        }
+
+        followingUsers = [...cachedUsers, ...dbUsers];
+    } else {
+        const page1Shown = Math.min(cachedIds.length, limit);
+        const dbAlreadyShownOnPage1 = limit - page1Shown;
+        const dbSkip = dbAlreadyShownOnPage1 + (page - 2) * limit;
+
+        const dbFollowing = await Follower.find({
+            followerId: userId,
+            userId: { $nin: cachedIds },
+        })
+            .sort({ createdAt: -1 })
+            .skip(dbSkip)
+            .limit(limit)
+            .populate('userId', 'username profileImageUrl fullName isVerified bio isBusinessProfile')
+            .lean();
+
+        followingUsers = dbFollowing.map(f => f.userId).filter(Boolean);
+    }
+
     const followingWithBadges = await addBadgesToUsers(followingUsers);
-    
-    res.status(200).json(new ApiResponse(200, followingWithBadges, "Following fetched successfully"));
+    const hasMore = page * limit < totalCount;
+
+    res.status(200).json(new ApiResponse(200, {
+        following: followingWithBadges,
+        totalCount,
+        page,
+        limit,
+        hasMore,
+    }, "Following fetched successfully"));
 });
 
 // Approve follow request
@@ -203,12 +399,26 @@ export const approveFollowRequest = asyncHandler(async (req, res) => {
         throw new ApiError(404, "Follow request not found");
     }
 
-    // Create the follow relationship
-    await Follower.create({ userId: recipientId, followerId: requesterId });
+    // Try Redis-first (deferred DB write via 4-hourly cron)
+    // requesterId is now following recipientId
+    const redisOk = await onUserFollowed(requesterId, recipientId);
 
-    // Update User model arrays
-    await User.findByIdAndUpdate(recipientId, { $addToSet: { followers: requesterId } });
-    await User.findByIdAndUpdate(requesterId, { $addToSet: { following: recipientId } });
+    if (!redisOk) {
+        // Redis is down — fall back to direct DB write
+        await Follower.create({ userId: recipientId, followerId: requesterId });
+        await User.findByIdAndUpdate(recipientId, { $addToSet: { followers: requesterId } });
+        await User.findByIdAndUpdate(requesterId, { $addToSet: { following: recipientId } });
+    }
+
+    // Both count updates must succeed together — roll back if either fails
+    let approvedFollowersCount;
+    try {
+        approvedFollowersCount = await incrFollowersCount(recipientId.toString());
+        await incrFollowingCount(requesterId.toString());
+    } catch (err) {
+        if (approvedFollowersCount !== undefined) decrFollowersCount(recipientId.toString()).catch(() => {});
+        // Non-fatal for approval — counts will self-heal on next profile load
+    }
 
     // Create notification for approval
     await createFollowNotification({ recipientId: requesterId, sourceUserId: recipientId, isApproval: true });
@@ -265,20 +475,20 @@ export const getPendingFollowRequests = asyncHandler(async (req, res) => {
     const { page = 1, limit = 10 } = req.query;
     const skip = (page - 1) * limit;
 
-    const requests = await FollowRequest.find({ 
-        recipientId: userId, 
-        status: 'pending' 
+    const requests = await FollowRequest.find({
+        recipientId: userId,
+        status: 'pending'
     })
         .sort({ createdAt: -1 })
         .skip(skip)
         .limit(parseInt(limit))
         .populate('requesterId', 'username fullName profileImageUrl');
 
-    const totalRequests = await FollowRequest.countDocuments({ 
-        recipientId: userId, 
-        status: 'pending' 
+    const totalRequests = await FollowRequest.countDocuments({
+        recipientId: userId,
+        status: 'pending'
     });
-    
+
     // Add badges to requesters
     const requestsWithBadges = await addBadgesToUsers(requests.map(req => req.requesterId));
     const requestersMap = new Map(requestsWithBadges.map(user => [user._id.toString(), user]));
@@ -304,20 +514,20 @@ export const getSentFollowRequests = asyncHandler(async (req, res) => {
     const { page = 1, limit = 10 } = req.query;
     const skip = (page - 1) * limit;
 
-    const requests = await FollowRequest.find({ 
-        requesterId: userId, 
-        status: 'pending' 
+    const requests = await FollowRequest.find({
+        requesterId: userId,
+        status: 'pending'
     })
         .sort({ createdAt: -1 })
         .skip(skip)
         .limit(parseInt(limit))
         .populate('recipientId', 'username fullName profileImageUrl');
 
-    const totalRequests = await FollowRequest.countDocuments({ 
-        requesterId: userId, 
-        status: 'pending' 
+    const totalRequests = await FollowRequest.countDocuments({
+        requesterId: userId,
+        status: 'pending'
     });
-    
+
     // Add badges to recipients
     const recipientsWithBadges = await addBadgesToUsers(requests.map(req => req.recipientId));
     const recipientsMap = new Map(recipientsWithBadges.map(user => [user._id.toString(), user]));

--- a/src/controllers/subscription.controllers.js
+++ b/src/controllers/subscription.controllers.js
@@ -466,10 +466,11 @@ export const verifySubscriptionPayment = asyncHandler(async (req, res) => {
         await business.save();
     }
 
-    // Invalidate feed caches
+    // Invalidate feed and profile caches (subscription badge/visibility changed)
     try {
-        const { FeedCacheManager } = await import('../utlis/cache.utils.js');
+        const { FeedCacheManager, UserCacheManager } = await import('../utlis/cache.utils.js');
         await Promise.allSettled([
+            UserCacheManager.invalidateUserProfile(userId.toString()),
             FeedCacheManager.invalidateUserFeed(userId),
             FeedCacheManager.invalidateExploreFeed(),
             FeedCacheManager.invalidateTrendingFeed()
@@ -618,19 +619,17 @@ export const testUpgradeSubscription = asyncHandler(async (req, res) => {
         await business.save();
     }
 
-    // ✅ CRITICAL: Invalidate all feed caches when subscription changes
-    // This ensures business posts appear/disappear immediately based on payment status
+    // Invalidate feed and profile caches (subscription badge/visibility changed)
     try {
-        const { FeedCacheManager } = await import('../utlis/cache.utils.js');
+        const { FeedCacheManager, UserCacheManager } = await import('../utlis/cache.utils.js');
 
-        // Invalidate all feed types since business post visibility affects them all
         await Promise.allSettled([
+            UserCacheManager.invalidateUserProfile(userId.toString()),
             FeedCacheManager.invalidateUserFeed(userId),
             FeedCacheManager.invalidateExploreFeed(),
             FeedCacheManager.invalidateTrendingFeed()
         ]);
 
-        // Also invalidate Redis cache patterns for home feeds
         const { redisClient } = await import('../config/redis.config.js');
         const feedKeys = await redisClient.keys('fn:user:*:feed:*');
         if (feedKeys.length > 0) {

--- a/src/controllers/user.controllers.js
+++ b/src/controllers/user.controllers.js
@@ -439,7 +439,37 @@ const logOutUser = asyncHandler(async (req, res) => {
 
 const getUserProfile = asyncHandler(async (req, res) => {
     const userId = req.user?._id;
+    const userIdStr = userId.toString();
 
+    const { RedisKeys, RedisTTL } = await import('../config/redis.config.js');
+    const { CacheManager } = await import('../utlis/cache.utils.js');
+    const { getFollowersCount, getFollowingCount } = await import('../utlis/followCount.utils.js');
+
+    const profileCacheKey = RedisKeys.userProfile(userIdStr);
+
+    // Try to serve from Redis profile cache
+    const cachedProfile = await CacheManager.get(profileCacheKey);
+
+    // Always fetch live follow counts (Redis count keys with DB fallback)
+    const [followersCount, followingCount, postsCount] = await Promise.all([
+        getFollowersCount(userIdStr),
+        getFollowingCount(userIdStr),
+        Post.countDocuments({ userId }),
+    ]);
+
+    if (cachedProfile) {
+        // Stitch the live counts into the cached profile and return
+        return res.status(200).json(
+            new ApiResponse(200, {
+                ...cachedProfile,
+                followersCount,
+                followingCount,
+                postsCount,
+            }, "User profile retrieved successfully")
+        );
+    }
+
+    // Cache miss — build from DB
     const user = await User.findById(userId).select(
         "username fullName email phoneNumber address gender dateOfBirth bio profileImageUrl location link followers following posts isBusinessProfile businessProfileId isBlueTickVerified isEmailVerified isPhoneVerified isPhoneNumberHidden isAddressHidden privacy isFullPrivate createdAt"
     );
@@ -448,17 +478,11 @@ const getUserProfile = asyncHandler(async (req, res) => {
         throw new ApiError(404, "User not found");
     }
 
-    // Count from actual collections instead of using outdated User model arrays
-    const followersCount = await Follower.countDocuments({ userId });
-    const followingCount = await Follower.countDocuments({ followerId: userId });
-    const postsCount = await Post.countDocuments({ userId });
-
     // Get business profile information if user is a business profile
     let businessInfo = null;
-    let isContentVisible = true; // Non-business accounts always have visible content
+    let isContentVisible = true;
     if (user.isBusinessProfile) {
         businessInfo = await Business.findOne({ userId }).select('postSettings isVerified subscriptionStatus plan');
-        // Check if business content is visible (active payment plan)
         if (businessInfo) {
             isContentVisible = businessInfo.subscriptionStatus === 'active' && businessInfo.plan !== 'plan1';
         }
@@ -467,7 +491,8 @@ const getUserProfile = asyncHandler(async (req, res) => {
     // Get subscription badge
     const subscriptionBadge = await user.getSubscriptionBadge();
 
-    const userProfile = {
+    // Profile snapshot — excludes dynamic counts which are always stitched from Redis
+    const profileSnapshot = {
         _id: user._id,
         username: user.username,
         email: user.email,
@@ -485,7 +510,6 @@ const getUserProfile = asyncHandler(async (req, res) => {
         isAddressHidden: user.isAddressHidden,
         privacy: user.privacy,
         isFullPrivate: user.isFullPrivate,
-        // Add business-specific fields
         productEnabled: user.isBusinessProfile ? (businessInfo?.postSettings?.allowProductPosts ?? true) : null,
         serviceEnabled: user.isBusinessProfile ? (businessInfo?.postSettings?.allowServicePosts ?? true) : null,
         isVerified: user.isBusinessProfile ? (businessInfo?.isVerified ?? false) : null,
@@ -493,29 +517,24 @@ const getUserProfile = asyncHandler(async (req, res) => {
         contentVisibilityMessage: user.isBusinessProfile && !isContentVisible
             ? 'Content is currently hidden. Activate your payment plan to make posts visible.'
             : null,
-        // Add subscription badge
-        subscriptionBadge: subscriptionBadge,
+        subscriptionBadge,
         createdAt: user.createdAt,
         bio: user.bio,
         link: user.link,
         location: user.location,
         profileImageUrl: user.profileImageUrl,
-        followersCount,
-        followingCount,
-        postsCount
     };
 
-    // Cache the response if caching is available
-    if (res.locals.cacheKey && res.locals.cacheTTL) {
-        await setCache(res.locals.cacheKey, {
-            success: true,
-            data: userProfile,
-            message: "User profile retrieved successfully"
-        }, res.locals.cacheTTL);
-    }
+    // Cache the profile snapshot (without dynamic counts) for 1 hour
+    await CacheManager.set(profileCacheKey, profileSnapshot, RedisTTL.USER_PROFILE);
 
     return res.status(200).json(
-        new ApiResponse(200, userProfile, "User profile retrieved successfully")
+        new ApiResponse(200, {
+            ...profileSnapshot,
+            followersCount,
+            followingCount,
+            postsCount,
+        }, "User profile retrieved successfully")
     );
 });
 
@@ -1315,11 +1334,14 @@ const getOtherUserProfile = asyncHandler(async (req, res) => {
         status: 'pending'
     });
 
-    // Calculate counts
-    const followersCount = await Follower.countDocuments({ userId: targetUser._id });
-    const followingCount = await Follower.countDocuments({ followerId: targetUser._id });
-    // Count posts directly from Post collection
-    const postsCount = await Post.countDocuments({ userId: targetUser._id });
+    // Calculate counts — Redis-first with DB fallback
+    const { getFollowersCount, getFollowingCount } = await import('../utlis/followCount.utils.js');
+    const targetIdStr = targetUser._id.toString();
+    const [followersCount, followingCount, postsCount] = await Promise.all([
+        getFollowersCount(targetIdStr),
+        getFollowingCount(targetIdStr),
+        Post.countDocuments({ userId: targetUser._id }),
+    ]);
 
     // Get business ID and visibility status if user has a business profile
     let businessId = null;

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,10 @@ import http from 'http';
 import socketManager from './config/socket.js';
 import './config/firebase-admin.config.js'; // Initialize Firebase Admin on startup
 import { startSubscriptionExpiryJob } from './jobs/subscriptionExpiry.job.js';
+// import { startLikeSyncJob } from './jobs/likeSync.job.js';
+import { startFollowSyncJob } from './jobs/followSync.job.js';
+// import { seedLikesToRedis } from './scripts/seedLikesToRedis.js';
+import { redisClient } from './config/redis.config.js';
 
 
 
@@ -41,10 +45,22 @@ connectDB()
 
         const PORT = process.env.PORT || 3000;
 
+        // Seed Redis with DB like state once — cron keeps it in sync after that.
+        // Key has no TTL so it persists until Redis is flushed/restarted.
+        // redisClient.get('fn:redis:likes:seeded').then(seeded => {
+        //     if (!seeded) {
+        //         seedLikesToRedis()
+        //             .then(() => redisClient.set('fn:redis:likes:seeded', '1'))
+        //             .catch(err => console.error('❌ Redis like seed failed:', err));
+        //     }
+        // });
+
         server.listen(PORT, '0.0.0.0', () => {
 
-            // Start subscription expiry cron jobs
+            // Start cron jobs
             startSubscriptionExpiryJob();
+            // startLikeSyncJob();
+            startFollowSyncJob();
         });
 
         server.on('error', (error) => {

--- a/src/jobs/followSync.job.js
+++ b/src/jobs/followSync.job.js
@@ -1,0 +1,317 @@
+import cron from 'node-cron';
+import mongoose from 'mongoose';
+import { redisClient, RedisKeys } from '../config/redis.config.js';
+import Follower from '../models/follower.models.js';
+import { User } from '../models/user.models.js';
+
+const DIRTY_KEY = RedisKeys.followsDirty();
+const SYNCING_KEY = 'fn:follows:syncing';
+const BATCH_SIZE = 100;
+
+export function startFollowSyncJob() {
+    // Every 4 hours: flush dirty follow/unfollow ops to DB
+    cron.schedule('0 */4 * * *', async () => {
+        console.log('[FollowSync] Starting follow sync...');
+        try {
+            await syncFollowsToDB();
+        } catch (err) {
+            console.error('[FollowSync] Job failed:', err);
+        }
+    });
+
+    // Every 4 hours at :30 — runs after syncFollowsToDB finishes writing to DB,
+    // then immediately rebuilds Redis lists so they reflect the latest DB state.
+    cron.schedule('30 */4 * * *', async () => {
+        console.log('[FollowSync] Starting temp flush + Redis list refresh...');
+        try {
+            await flushFollowTempToDB();       // 1. write temp SETs to DB
+            await refreshFollowListsFromDB();  // 2. rebuild Redis LRANGEs from updated DB
+        } catch (err) {
+            console.error('[FollowSync] Flush+refresh failed:', err);
+        }
+    });
+}
+
+async function syncFollowsToDB() {
+    // Atomically hand off the dirty set so new follow/unfollow ops land in a fresh key
+    try {
+        await redisClient.rename(DIRTY_KEY, SYNCING_KEY);
+    } catch (err) {
+        if (err.message.includes('no such key') || err.message.includes('ERR no such key')) {
+            console.log('[FollowSync] Nothing to sync');
+            return;
+        }
+        throw err;
+    }
+
+    const toFollow = [];   // { followerId, targetUserId }
+    const toUnfollow = []; // { followerId, targetUserId }
+    // Deduplicate across SSCAN cursor positions
+    const seen = new Set();
+    let cursor = '0';
+
+    do {
+        const [nextCursor, members] = await redisClient.sscan(SYNCING_KEY, cursor, 'COUNT', BATCH_SIZE);
+        cursor = nextCursor;
+        if (!members.length) continue;
+
+        const unique = members.filter(pair => !seen.has(pair));
+        unique.forEach(pair => seen.add(pair));
+        if (!unique.length) continue;
+
+        const keys = unique.map(pair => {
+            const [fid, tid] = pair.split(':');
+            return RedisKeys.userFollowStatus(fid, tid);
+        });
+        const statuses = await redisClient.mget(...keys);
+
+        unique.forEach((pair, i) => {
+            const [followerId, targetUserId] = pair.split(':');
+            const status = statuses[i];
+            if (status === null) return; // TTL expired before sync — DB is already authoritative, skip
+            if (status === '1') toFollow.push({ followerId, targetUserId });
+            else toUnfollow.push({ followerId, targetUserId });
+        });
+    } while (cursor !== '0');
+
+    // Upsert Follower documents for new follows
+    if (toFollow.length) {
+        const followerOps = toFollow.map(({ followerId, targetUserId }) => ({
+            updateOne: {
+                filter: {
+                    userId: new mongoose.Types.ObjectId(targetUserId),
+                    followerId: new mongoose.Types.ObjectId(followerId),
+                },
+                update: {
+                    $setOnInsert: {
+                        userId: new mongoose.Types.ObjectId(targetUserId),
+                        followerId: new mongoose.Types.ObjectId(followerId),
+                    },
+                },
+                upsert: true,
+            },
+        }));
+        await Follower.bulkWrite(followerOps, { ordered: false });
+
+        // Update User.followers[] and User.following[] arrays for follows
+        const userOps = [];
+        for (const { followerId, targetUserId } of toFollow) {
+            userOps.push({
+                updateOne: {
+                    filter: { _id: new mongoose.Types.ObjectId(targetUserId) },
+                    update: { $addToSet: { followers: new mongoose.Types.ObjectId(followerId) } },
+                },
+            });
+            userOps.push({
+                updateOne: {
+                    filter: { _id: new mongoose.Types.ObjectId(followerId) },
+                    update: { $addToSet: { following: new mongoose.Types.ObjectId(targetUserId) } },
+                },
+            });
+        }
+        if (userOps.length) await User.bulkWrite(userOps, { ordered: false });
+    }
+
+    // Follower documents are deleted synchronously on unfollow (in onUserUnfollowed).
+    // Only User.followers[]/following[] arrays need to be cleaned up here.
+    if (toUnfollow.length) {
+        const userOps = [];
+        for (const { followerId, targetUserId } of toUnfollow) {
+            userOps.push({
+                updateOne: {
+                    filter: { _id: new mongoose.Types.ObjectId(targetUserId) },
+                    update: { $pull: { followers: new mongoose.Types.ObjectId(followerId) } },
+                },
+            });
+            userOps.push({
+                updateOne: {
+                    filter: { _id: new mongoose.Types.ObjectId(followerId) },
+                    update: { $pull: { following: new mongoose.Types.ObjectId(targetUserId) } },
+                },
+            });
+        }
+        if (userOps.length) await User.bulkWrite(userOps, { ordered: false });
+    }
+
+    await redisClient.del(SYNCING_KEY);
+
+    console.log(
+        `[FollowSync] Done — followed ${toFollow.length}, unfollowed ${toUnfollow.length}`
+    );
+}
+
+/**
+ * Every 2 hours: flush followers:temp and following:temp SETs to the Follower collection.
+ *
+ * followers:temp for B contains A's IDs → Follower { userId: B, followerId: A }
+ * following:temp for A contains B's IDs → Follower { userId: B, followerId: A }
+ *
+ * After flushing each temp SET it is deleted. temp:active is left intact for refreshFollowListsFromDB.
+ */
+async function flushFollowTempToDB() {
+    const tempActiveKey = RedisKeys.followTempActiveUsers();
+
+    let activeUserIds;
+    try {
+        activeUserIds = await redisClient.smembers(tempActiveKey);
+    } catch (err) {
+        console.error('[FollowSync][flushTemp] Could not read temp:active set:', err.message);
+        return;
+    }
+
+    if (!activeUserIds.length) {
+        console.log('[FollowSync][flushTemp] Nothing to flush');
+        return;
+    }
+
+    let followerOpsTotal = 0;
+
+    for (const userId of activeUserIds) {
+        // ── Flush followers:temp for this userId ─────────────────────────────
+        // B's followers:temp has A's IDs → Follower { userId: B, followerId: A }
+        try {
+            const followersTempKey = RedisKeys.followersTemp(userId);
+            const followerIds = await redisClient.smembers(followersTempKey);
+
+            if (followerIds.length) {
+                const ops = followerIds.map(followerId => ({
+                    updateOne: {
+                        filter: {
+                            userId: new mongoose.Types.ObjectId(userId),
+                            followerId: new mongoose.Types.ObjectId(followerId),
+                        },
+                        update: {
+                            $setOnInsert: {
+                                userId: new mongoose.Types.ObjectId(userId),
+                                followerId: new mongoose.Types.ObjectId(followerId),
+                            },
+                        },
+                        upsert: true,
+                    },
+                }));
+                await Follower.bulkWrite(ops, { ordered: false });
+                followerOpsTotal += ops.length;
+            }
+
+            await redisClient.del(followersTempKey);
+        } catch (err) {
+            console.error(`[FollowSync][flushTemp] followers:temp error for user ${userId}:`, err.message);
+        }
+
+        // ── Flush following:temp for this userId ─────────────────────────────
+        // A's following:temp has B's IDs → Follower { userId: B, followerId: A }
+        try {
+            const followingTempKey = RedisKeys.followingTemp(userId);
+            const followingIds = await redisClient.smembers(followingTempKey);
+
+            if (followingIds.length) {
+                const ops = followingIds.map(targetUserId => ({
+                    updateOne: {
+                        filter: {
+                            userId: new mongoose.Types.ObjectId(targetUserId),
+                            followerId: new mongoose.Types.ObjectId(userId),
+                        },
+                        update: {
+                            $setOnInsert: {
+                                userId: new mongoose.Types.ObjectId(targetUserId),
+                                followerId: new mongoose.Types.ObjectId(userId),
+                            },
+                        },
+                        upsert: true,
+                    },
+                }));
+                await Follower.bulkWrite(ops, { ordered: false });
+                followerOpsTotal += ops.length;
+            }
+
+            await redisClient.del(followingTempKey);
+        } catch (err) {
+            console.error(`[FollowSync][flushTemp] following:temp error for user ${userId}:`, err.message);
+        }
+    }
+    // to know which users' LRANGEs need rebuilding from DB after this flush.
+
+    console.log(`[FollowSync][flushTemp] Done — ${followerOpsTotal} Follower upserts across ${activeUserIds.length} users`);
+}
+
+/**
+ * Every 10 hours: re-seed the follower/following Redis LISTs from DB for all users
+ * that have had temp activity, then clear their temp SETs and the active tracking SET.
+ *
+ * Uses DEL + RPUSH (not LPUSH) so the list order matches the DB sort order (newest → oldest).
+ */
+async function refreshFollowListsFromDB() {
+    const LIST_TTL = 12 * 24 * 60 * 60; // 12 days — mirrors followEngagement.utils.js
+    const tempActiveKey = RedisKeys.followTempActiveUsers();
+
+    let activeUserIds;
+    try {
+        activeUserIds = await redisClient.smembers(tempActiveKey);
+    } catch (err) {
+        console.error('[FollowSync][refresh] Could not read temp:active set:', err.message);
+        return;
+    }
+
+    if (!activeUserIds.length) {
+        console.log('[FollowSync][refresh] Nothing to refresh');
+        return;
+    }
+
+    for (const userId of activeUserIds) {
+        // ── Refresh followers LIST ────────────────────────────────────────────
+        try {
+            const top15Followers = await Follower.find({ userId })
+                .sort({ createdAt: -1 })
+                .limit(15)
+                .select('followerId')
+                .lean();
+
+            const followersListKey = RedisKeys.userFollowers(userId);
+            const followersTempKey = RedisKeys.followersTemp(userId);
+
+            const pipeline = redisClient.pipeline();
+            pipeline.del(followersListKey);
+            if (top15Followers.length) {
+                // RPUSH in DB order (already sorted newest→oldest), so list[0] = newest
+                pipeline.rpush(followersListKey, ...top15Followers.map(f => f.followerId.toString()));
+                pipeline.expire(followersListKey, LIST_TTL);
+            }
+            pipeline.del(followersTempKey);
+            await pipeline.exec();
+        } catch (err) {
+            console.error(`[FollowSync][refresh] followers refresh error for user ${userId}:`, err.message);
+        }
+
+        // ── Refresh following LIST ────────────────────────────────────────────
+        try {
+            const top15Following = await Follower.find({ followerId: userId })
+                .sort({ createdAt: -1 })
+                .limit(15)
+                .select('userId')
+                .lean();
+
+            const followingListKey = RedisKeys.userFollowing(userId);
+            const followingTempKey = RedisKeys.followingTemp(userId);
+
+            const pipeline = redisClient.pipeline();
+            pipeline.del(followingListKey);
+            if (top15Following.length) {
+                pipeline.rpush(followingListKey, ...top15Following.map(f => f.userId.toString()));
+                pipeline.expire(followingListKey, LIST_TTL);
+            }
+            pipeline.del(followingTempKey);
+            await pipeline.exec();
+        } catch (err) {
+            console.error(`[FollowSync][refresh] following refresh error for user ${userId}:`, err.message);
+        }
+    }
+
+    // Clear the active-users tracking SET
+    try {
+        await redisClient.del(tempActiveKey);
+    } catch (err) {
+        console.error('[FollowSync][refresh] Could not delete temp:active set:', err.message);
+    }
+
+    console.log(`[FollowSync][refresh] Done — refreshed lists for ${activeUserIds.length} users`);
+}

--- a/src/jobs/likeSync.job.js
+++ b/src/jobs/likeSync.job.js
@@ -1,0 +1,137 @@
+import cron from 'node-cron';
+import mongoose from 'mongoose';
+import { redisClient, RedisKeys } from '../config/redis.config.js';
+import Like from '../models/like.models.js';
+import Post from '../models/userPost.models.js';
+
+const DIRTY_KEY = RedisKeys.likesDirty();
+const SYNCING_KEY = 'fn:likes:syncing';
+const BATCH_SIZE = 100;
+
+// export function startLikeSyncJob() {
+//     // Run every 4 hours
+//     cron.schedule('0 */4 * * *', async () => {
+//         console.log('[LikeSync] Starting daily like sync...');
+//         try {
+//             await syncLikesToDB();
+//         } catch (err) {
+//             console.error('[LikeSync] Job failed:', err);
+//         }
+//     });
+// }
+
+export function startLikeSyncJob() {
+    // Run every 5 minutes
+    cron.schedule('*/5 * * * *', async () => {
+        console.log('[LikeSync] Starting like sync...');
+        try {
+            await syncLikesToDB();
+        } catch (err) {
+            console.error('[LikeSync] Job failed:', err);
+        }
+    });
+}
+
+async function syncLikesToDB() {
+    // Atomically hand off the dirty set so new likes land in a fresh key
+    try {
+        await redisClient.rename(DIRTY_KEY, SYNCING_KEY);
+    } catch (err) {
+        if (err.message.includes('no such key') || err.message.includes('ERR no such key')) {
+            console.log('[LikeSync] Nothing to sync');
+            return;
+        }
+        throw err;
+    }
+
+    const toUpsert = [];  // { userId, postId }
+    const toDelete = [];  // { userId, postId }
+    const affectedPostIds = new Set();
+    // SSCAN may return the same member across multiple cursor positions during rehashing;
+    // deduplicate here so we don't upsert/delete the same pair twice.
+    const seen = new Set();
+    let cursor = '0';
+
+    // SSCAN through the syncing set in fixed-size batches
+    do {
+        const [nextCursor, members] = await redisClient.sscan(SYNCING_KEY, cursor, 'COUNT', BATCH_SIZE);
+        cursor = nextCursor;
+        if (!members.length) continue;
+
+        // Filter out duplicates before hitting Redis with MGET
+        const unique = members.filter(pair => !seen.has(pair));
+        unique.forEach(pair => seen.add(pair));
+        if (!unique.length) continue;
+
+        const keys = unique.map(pair => {
+            const [uid, pid] = pair.split(':');
+            return RedisKeys.userLikedPost(uid, pid);
+        });
+        const statuses = await redisClient.mget(...keys);
+
+        unique.forEach((pair, i) => {
+            const [userId, postId] = pair.split(':');
+            const status = statuses[i];
+            if (status === null) return; // TTL expired before sync — skip (DB already authoritative)
+            affectedPostIds.add(postId);
+            if (status === '1') toUpsert.push({ userId, postId });
+            else toDelete.push({ userId, postId });
+        });
+    } while (cursor !== '0');
+
+    // Upsert likes (insert if not exists, no-op if duplicate)
+    if (toUpsert.length) {
+        const ops = toUpsert.map(({ userId, postId }) => ({
+            updateOne: {
+                filter: {
+                    userId: new mongoose.Types.ObjectId(userId),
+                    postId: new mongoose.Types.ObjectId(postId),
+                },
+                update: {
+                    $setOnInsert: {
+                        userId: new mongoose.Types.ObjectId(userId),
+                        postId: new mongoose.Types.ObjectId(postId),
+                    },
+                },
+                upsert: true,
+            },
+        }));
+        await Like.bulkWrite(ops, { ordered: false });
+    }
+
+    // Delete unliked records
+    if (toDelete.length) {
+        const conditions = toDelete.map(({ userId, postId }) => ({
+            userId: new mongoose.Types.ObjectId(userId),
+            postId: new mongoose.Types.ObjectId(postId),
+        }));
+        await Like.deleteMany({ $or: conditions });
+    }
+
+    // Sync engagement.likes counts from Redis back to Post documents
+    const postIdArr = [...affectedPostIds];
+    if (postIdArr.length) {
+        const countKeys = postIdArr.map(id => RedisKeys.postLikesCount(id));
+        const counts = await redisClient.mget(...countKeys);
+
+        const ops = [];
+        postIdArr.forEach((postId, i) => {
+            if (counts[i] !== null) {
+                ops.push({
+                    updateOne: {
+                        filter: { _id: new mongoose.Types.ObjectId(postId) },
+                        update: { $set: { 'engagement.likes': parseInt(counts[i], 10) } },
+                    },
+                });
+            }
+        });
+        if (ops.length) await Post.bulkWrite(ops, { ordered: false });
+    }
+
+    await redisClient.del(SYNCING_KEY);
+
+    console.log(
+        `[LikeSync] Done — upserted ${toUpsert.length}, deleted ${toDelete.length}, ` +
+        `updated counts for ${affectedPostIds.size} posts`
+    );
+}

--- a/src/jobs/subscriptionExpiry.job.js
+++ b/src/jobs/subscriptionExpiry.job.js
@@ -61,9 +61,11 @@ export const handleExpiredSubscriptions = async () => {
 
                 }
 
-                // 3. Invalidate cache for user
+                // 3. Invalidate feed and profile caches (subscription badge changed on expiry)
                 try {
+                    const { UserCacheManager } = await import('../utlis/cache.utils.js');
                     await Promise.allSettled([
+                        UserCacheManager.invalidateUserProfile(userId.toString()),
                         FeedCacheManager.invalidateUserFeed(userId),
                         FeedCacheManager.invalidateExploreFeed(),
                         FeedCacheManager.invalidateTrendingFeed()

--- a/src/scripts/seedFollowersToRedis.js
+++ b/src/scripts/seedFollowersToRedis.js
@@ -1,0 +1,131 @@
+/**
+ * One-time (or periodic) warm-up script: seeds Redis with the current follower/following
+ * state so that getFollowers, getFollowing, and onUserFollowed/onUserUnfollowed all have
+ * accurate LIST and count data without hitting the DB on cold start.
+ *
+ * Run manually:  node src/scripts/seedFollowersToRedis.js
+ * Or call seedFollowersToRedis() at server startup after connectDB().
+ *
+ * What it writes per user:
+ *   fn:user:{userId}:followers       — Redis LIST of up to 15 newest follower IDs (TTL: 12 days)
+ *   fn:user:{userId}:following       — Redis LIST of up to 15 newest following IDs (TTL: 12 days)
+ *   fn:user:{userId}:followers:count — STRING count of total followers (TTL: 7 days)
+ *   fn:user:{userId}:following:count — STRING count of total following (TTL: 7 days)
+ *
+ * Temp SETs (followers:temp, following:temp, follows:temp:active) are DELeted so they
+ * start clean — any in-flight temp data that hasn't been flushed will be re-created by
+ * the next follow/unfollow operations.
+ */
+
+import 'dotenv/config';
+import connectDB from '../db/index.js';
+import { redisClient, RedisKeys, RedisTTL } from '../config/redis.config.js';
+import Follower from '../models/follower.models.js';
+import { User } from '../models/user.models.js';
+
+const USER_BATCH_SIZE = 200;
+const LIST_TTL = 12 * 24 * 60 * 60;   // 12 days
+const COUNT_TTL = RedisTTL.FOLLOW_COUNT; // 7 days
+
+export async function seedFollowersToRedis() {
+    console.log('[SeedFollowers] Starting Redis warm-up from DB...');
+
+    let processed = 0;
+    let cursor = null;
+
+    do {
+        // Fetch users in batches using cursor-based pagination
+        const query = User.find({}).select('_id').lean();
+        if (cursor) query.where('_id').gt(cursor);
+        const userBatch = await query.limit(USER_BATCH_SIZE);
+
+        if (!userBatch.length) break;
+        cursor = userBatch[userBatch.length - 1]._id;
+
+        for (const { _id: userId } of userBatch) {
+            const userIdStr = userId.toString();
+
+            try {
+                // ── Top-15 followers (newest first) ──────────────────────────
+                const [top15Followers, top15Following, followersCount, followingCount] = await Promise.all([
+                    Follower.find({ userId })
+                        .sort({ createdAt: -1 })
+                        .limit(15)
+                        .select('followerId')
+                        .lean(),
+                    Follower.find({ followerId: userId })
+                        .sort({ createdAt: -1 })
+                        .limit(15)
+                        .select('userId')
+                        .lean(),
+                    Follower.countDocuments({ userId }),
+                    Follower.countDocuments({ followerId: userId }),
+                ]);
+
+                const followersListKey = RedisKeys.userFollowers(userIdStr);
+                const followingListKey = RedisKeys.userFollowing(userIdStr);
+                const followersTempKey = RedisKeys.followersTemp(userIdStr);
+                const followingTempKey = RedisKeys.followingTemp(userIdStr);
+                const followersCountKey = RedisKeys.userFollowersCount(userIdStr);
+                const followingCountKey = RedisKeys.userFollowingCount(userIdStr);
+
+                const pipeline = redisClient.pipeline();
+
+                // Seed followers LIST (DEL first to avoid stale data)
+                pipeline.del(followersListKey);
+                if (top15Followers.length) {
+                    // RPUSH in sorted order (newest→oldest from DB), so list index 0 = newest
+                    pipeline.rpush(followersListKey, ...top15Followers.map(f => f.followerId.toString()));
+                    pipeline.expire(followersListKey, LIST_TTL);
+                }
+
+                // Seed following LIST
+                pipeline.del(followingListKey);
+                if (top15Following.length) {
+                    pipeline.rpush(followingListKey, ...top15Following.map(f => f.userId.toString()));
+                    pipeline.expire(followingListKey, LIST_TTL);
+                }
+
+                // Seed count keys
+                pipeline.set(followersCountKey, followersCount, 'EX', COUNT_TTL);
+                pipeline.set(followingCountKey, followingCount, 'EX', COUNT_TTL);
+
+                // Clear any stale temp SETs for this user
+                pipeline.del(followersTempKey);
+                pipeline.del(followingTempKey);
+
+                await pipeline.exec();
+                processed++;
+            } catch (err) {
+                console.error(`[SeedFollowers] Error seeding user ${userIdStr}:`, err.message);
+            }
+        }
+
+        console.log(`[SeedFollowers] Users processed: ${processed}`);
+
+        if (userBatch.length < USER_BATCH_SIZE) break;
+    } while (true);
+
+    // Clear the global temp:active tracking SET so the cron starts fresh
+    try {
+        await redisClient.del(RedisKeys.followTempActiveUsers());
+    } catch (err) {
+        console.error('[SeedFollowers] Could not clear temp:active set:', err.message);
+    }
+
+    console.log(`[SeedFollowers] Done — seeded ${processed} users`);
+}
+
+// Allow direct execution: node src/scripts/seedFollowersToRedis.js
+if (process.argv[1].includes('seedFollowersToRedis')) {
+    connectDB()
+        .then(() => seedFollowersToRedis())
+        .then(() => {
+            redisClient.quit();
+            process.exit(0);
+        })
+        .catch(err => {
+            console.error('[SeedFollowers] Fatal:', err);
+            process.exit(1);
+        });
+}

--- a/src/utlis/followCount.utils.js
+++ b/src/utlis/followCount.utils.js
@@ -1,0 +1,138 @@
+import { redisClient, RedisKeys, RedisTTL } from '../config/redis.config.js';
+import Follower from '../models/follower.models.js';
+
+const TTL = RedisTTL.FOLLOW_COUNT;
+
+async function _dbFollowersCount(userId) {
+    return Follower.countDocuments({ userId });
+}
+
+async function _dbFollowingCount(userId) {
+    return Follower.countDocuments({ followerId: userId });
+}
+
+/**
+ * Get followers count — Redis first, DB fallback with automatic seeding.
+ */
+export async function getFollowersCount(userId) {
+    const key = RedisKeys.userFollowersCount(userId);
+    try {
+        const val = await redisClient.get(key);
+        if (val !== null) return parseInt(val, 10);
+        const count = await _dbFollowersCount(userId);
+        await redisClient.set(key, count, 'EX', TTL);
+        return count;
+    } catch (err) {
+        console.error(`[FollowCount] getFollowersCount(${userId}):`, err.message);
+        return _dbFollowersCount(userId).catch(() => 0);
+    }
+}
+
+/**
+ * Get following count — Redis first, DB fallback with automatic seeding.
+ */
+export async function getFollowingCount(userId) {
+    const key = RedisKeys.userFollowingCount(userId);
+    try {
+        const val = await redisClient.get(key);
+        if (val !== null) return parseInt(val, 10);
+        const count = await _dbFollowingCount(userId);
+        await redisClient.set(key, count, 'EX', TTL);
+        return count;
+    } catch (err) {
+        console.error(`[FollowCount] getFollowingCount(${userId}):`, err.message);
+        return _dbFollowingCount(userId).catch(() => 0);
+    }
+}
+
+/**
+ * Increment followers count.
+ * Uses INCR-first so the operation is atomic. If INCR returns 1 the key was
+ * missing (Redis created it at 0 then incremented), so we re-seed from DB + 1
+ * to account for the deferred follow that hasn't been written to DB yet.
+ */
+export async function incrFollowersCount(userId) {
+    const key = RedisKeys.userFollowersCount(userId);
+    try {
+        const next = await redisClient.incr(key);
+        if (next === 1) {
+            // Key was just created — DB doesn't have the deferred follow yet, so +1
+            const dbCount = await _dbFollowersCount(userId);
+            const correct = dbCount + 1;
+            await redisClient.set(key, correct, 'EX', TTL);
+            return correct;
+        }
+        await redisClient.expire(key, TTL);
+        return next;
+    } catch (err) {
+        console.error(`[FollowCount] incrFollowersCount(${userId}):`, err.message);
+    }
+}
+
+/**
+ * Decrement followers count.
+ * Uses DECR-first so the operation is atomic. If DECR returns < 0 the key was
+ * missing (Redis created it at 0 then decremented to -1), so we re-seed from DB.
+ * The Follower doc is deleted synchronously by onUserUnfollowed before this runs,
+ * so the DB count already reflects the removal.
+ */
+export async function decrFollowersCount(userId) {
+    const key = RedisKeys.userFollowersCount(userId);
+    try {
+        const next = await redisClient.decr(key);
+        if (next < 0) {
+            const dbCount = await _dbFollowersCount(userId);
+            const correct = Math.max(0, dbCount);
+            await redisClient.set(key, correct, 'EX', TTL);
+            return correct;
+        }
+        await redisClient.expire(key, TTL);
+        return next;
+    } catch (err) {
+        console.error(`[FollowCount] decrFollowersCount(${userId}):`, err.message);
+    }
+}
+
+/**
+ * Increment following count.
+ * Uses INCR-first so the operation is atomic. If INCR returns 1 the key was
+ * missing, so we re-seed from DB + 1 to account for the deferred follow.
+ */
+export async function incrFollowingCount(userId) {
+    const key = RedisKeys.userFollowingCount(userId);
+    try {
+        const next = await redisClient.incr(key);
+        if (next === 1) {
+            const dbCount = await _dbFollowingCount(userId);
+            const correct = dbCount + 1;
+            await redisClient.set(key, correct, 'EX', TTL);
+            return correct;
+        }
+        await redisClient.expire(key, TTL);
+        return next;
+    } catch (err) {
+        console.error(`[FollowCount] incrFollowingCount(${userId}):`, err.message);
+    }
+}
+
+/**
+ * Decrement following count.
+ * Uses DECR-first so the operation is atomic. If DECR returns < 0 the key was
+ * missing, so we re-seed from DB (which already reflects the deletion).
+ */
+export async function decrFollowingCount(userId) {
+    const key = RedisKeys.userFollowingCount(userId);
+    try {
+        const next = await redisClient.decr(key);
+        if (next < 0) {
+            const dbCount = await _dbFollowingCount(userId);
+            const correct = Math.max(0, dbCount);
+            await redisClient.set(key, correct, 'EX', TTL);
+            return correct;
+        }
+        await redisClient.expire(key, TTL);
+        return next;
+    } catch (err) {
+        console.error(`[FollowCount] decrFollowingCount(${userId}):`, err.message);
+    }
+}

--- a/src/utlis/followEngagement.utils.js
+++ b/src/utlis/followEngagement.utils.js
@@ -1,0 +1,136 @@
+import { redisClient, RedisKeys, RedisTTL } from '../config/redis.config.js';
+import Follower from '../models/follower.models.js';
+
+const FOLLOW_STATUS_TTL = RedisTTL.FOLLOW_STATUS;
+
+const MAX_FOLLOW_LIST = 15;
+const LIST_TTL = 12 * 24 * 60 * 60;   // 12 days
+const TEMP_TTL = 3 * 60 * 60;          // 3h safety TTL on temp SET
+const TEMP_ACTIVE_TTL = 25 * 60 * 60;  // 25h
+
+/**
+ * Check if followerId is following targetUserId.
+ * Redis-first: '1'→following, '0'→not following, null→DB fallback.
+ * If Redis is down, reads directly from DB.
+ */
+export async function getFollowStatus(followerId, targetUserId) {
+    const followerIdStr = followerId.toString();
+    const targetIdStr = targetUserId.toString();
+    try {
+        const val = await redisClient.get(RedisKeys.userFollowStatus(followerIdStr, targetIdStr));
+        if (val !== null) return val === '1';
+        return !!(await Follower.findOne({ userId: targetUserId, followerId }));
+    } catch {
+        return !!(await Follower.findOne({ userId: targetUserId, followerId }));
+    }
+}
+
+/**
+ * Call when A follows B.
+ * - Sets follow-status key to '1' and marks dirty for 4-hourly DB sync.
+ * - LPUSH+LTRIM A's ID into B's followers LIST (newest-first, max 15).
+ * - LPUSH+LTRIM B's ID into A's following LIST (newest-first, max 15).
+ * - SADD A's ID into B's followers:temp SET (pending 2h flush to DB).
+ * - SADD B's ID into A's following:temp SET (pending 2h flush to DB).
+ * - SADD both A and B into fn:follows:temp:active so the cron knows who to flush.
+ * Returns true on success, false if Redis is down.
+ */
+export async function onUserFollowed(followerId, targetUserId) {
+    const followerIdStr = followerId.toString();
+    const targetIdStr = targetUserId.toString();
+    const dirtyKey = RedisKeys.followsDirty();
+    const followersListKey = RedisKeys.userFollowers(targetIdStr);
+    const followingListKey = RedisKeys.userFollowing(followerIdStr);
+    const followersTempKey = RedisKeys.followersTemp(targetIdStr);
+    const followingTempKey = RedisKeys.followingTemp(followerIdStr);
+    const tempActiveKey = RedisKeys.followTempActiveUsers();
+
+    try {
+        const pipeline = redisClient.pipeline();
+
+        // Follow-status + dirty set (existing behaviour)
+        pipeline.set(RedisKeys.userFollowStatus(followerIdStr, targetIdStr), '1', 'EX', FOLLOW_STATUS_TTL);
+        pipeline.sadd(dirtyKey, `${followerIdStr}:${targetIdStr}`);
+        pipeline.expire(dirtyKey, 25 * 60 * 60);
+
+        // B's followers LIST — push A to front, trim to 15
+        pipeline.lpush(followersListKey, followerIdStr);
+        pipeline.ltrim(followersListKey, 0, MAX_FOLLOW_LIST - 1);
+        pipeline.expire(followersListKey, LIST_TTL);
+
+        // A's following LIST — push B to front, trim to 15
+        pipeline.lpush(followingListKey, targetIdStr);
+        pipeline.ltrim(followingListKey, 0, MAX_FOLLOW_LIST - 1);
+        pipeline.expire(followingListKey, LIST_TTL);
+
+        // B's followers:temp SET — A's ID is pending DB flush
+        pipeline.sadd(followersTempKey, followerIdStr);
+        pipeline.expire(followersTempKey, TEMP_TTL);
+
+        // A's following:temp SET — B's ID is pending DB flush
+        pipeline.sadd(followingTempKey, targetIdStr);
+        pipeline.expire(followingTempKey, TEMP_TTL);
+
+        // Track active temp users so the cron knows who to flush
+        pipeline.sadd(tempActiveKey, targetIdStr, followerIdStr);
+        pipeline.expire(tempActiveKey, TEMP_ACTIVE_TTL);
+
+        await pipeline.exec();
+        return true;
+    } catch (err) {
+        console.error('[FollowEngagement] onUserFollowed error:', err.message);
+        return false;
+    }
+}
+
+/**
+ * Call when A unfollows B.
+ * - Sets follow-status key to '0' and marks dirty for 4-hourly sync.
+ * - LREM A's ID from B's followers LIST.
+ * - LREM B's ID from A's following LIST.
+ * - SREM A's ID from B's followers:temp SET.
+ * - SREM B's ID from A's following:temp SET.
+ * - Immediately deletes Follower doc so DB fallback never returns a stale state.
+ * Returns true on success, false if Redis is down.
+ */
+export async function onUserUnfollowed(followerId, targetUserId) {
+    const followerIdStr = followerId.toString();
+    const targetIdStr = targetUserId.toString();
+    const dirtyKey = RedisKeys.followsDirty();
+    const followersListKey = RedisKeys.userFollowers(targetIdStr);
+    const followingListKey = RedisKeys.userFollowing(followerIdStr);
+    const followersTempKey = RedisKeys.followersTemp(targetIdStr);
+    const followingTempKey = RedisKeys.followingTemp(followerIdStr);
+
+    try {
+        const pipeline = redisClient.pipeline();
+
+        // Follow-status + dirty set (existing behaviour)
+        pipeline.set(RedisKeys.userFollowStatus(followerIdStr, targetIdStr), '0', 'EX', FOLLOW_STATUS_TTL);
+        pipeline.sadd(dirtyKey, `${followerIdStr}:${targetIdStr}`);
+        pipeline.expire(dirtyKey, 25 * 60 * 60);
+
+        // Remove A from B's followers LIST
+        pipeline.lrem(followersListKey, 0, followerIdStr);
+
+        // Remove B from A's following LIST
+        pipeline.lrem(followingListKey, 0, targetIdStr);
+
+        // Remove A from B's followers:temp SET
+        pipeline.srem(followersTempKey, followerIdStr);
+
+        // Remove B from A's following:temp SET
+        pipeline.srem(followingTempKey, targetIdStr);
+
+        await pipeline.exec();
+
+        // Immediately delete Follower doc so DB fallback never returns a stale "following" state.
+        // (Follows are deferred; unfollows must be synchronous for correctness.)
+        await Follower.findOneAndDelete({ userId: targetUserId, followerId }).catch(() => {});
+
+        return true;
+    } catch (err) {
+        console.error('[FollowEngagement] onUserUnfollowed error:', err.message);
+        return false;
+    }
+}


### PR DESCRIPTION
- cache user profile for faster load
- store follower and follow count  on cache
- sync db with cron job and  resync the follower and follow count from the db
- maintain 15 to 20 follower and follow users on cache and periodically update the  invalidate and  enrich from the db