### PR TITLE
fix the over fetching of following,follow on fetch enpoinsts and fix batchIsLikedUsers

### DIFF
--- a/scripts/seedLikesToRedis.js
+++ b/scripts/seedLikesToRedis.js
@@ -4,9 +4,9 @@
  * Run:  node scripts/seedLikesToRedis.js
  *
  * What it writes:
- *   fn:user:{userId}:liked          Hash  field=postId  value='1'
- *   fn:post:{postId}:likedby        Hash  field=userId  value=JSON profile
- *   fn:post:{postId}:likes:count    String  value=N
+ *   fn:user:{userId}:liked          Set    members = postIds the user has liked
+ *   fn:post:{postId}:likedby        Hash   field=userId  value=JSON profile
+ *   fn:post:{postId}:likes:count    String value=N
  */
 
 import 'dotenv/config';
@@ -30,7 +30,7 @@ export async function seedLikesToRedis() {
     let cursor = null;
     let userKeyCount = 0;
 
-    console.log('[SeedLikes] Step 1/3 — writing per-user liked Hashes...');
+    console.log('[SeedLikes] Step 1/3 — writing per-user liked Sets...');
     do {
         const query = Like.find({ postId: { $ne: null } }).select('userId postId').lean();
         if (cursor) query.where('_id').gt(cursor);
@@ -38,7 +38,7 @@ export async function seedLikesToRedis() {
         if (!batch.length) break;
         cursor = batch[batch.length - 1]._id;
 
-        // Group by userId
+        // Group postIds by userId
         const byUser = new Map();
         for (const { userId, postId } of batch) {
             if (!userId || !postId) continue;
@@ -49,18 +49,16 @@ export async function seedLikesToRedis() {
 
         const pipeline = redisClient.pipeline();
         for (const [uid, postIds] of byUser) {
-            const hashKey = RedisKeys.userLikedHash(uid);
-            const args = [hashKey];
-            for (const pid of postIds) args.push(pid, '1');
-            pipeline.hset(...args);
-            pipeline.expire(hashKey, LIKE_TTL);
+            const setKey = RedisKeys.userLikedSet(uid);
+            pipeline.sadd(setKey, ...postIds);
+            pipeline.expire(setKey, LIKE_TTL);
             userKeyCount++;
         }
         await pipeline.exec();
 
         if (batch.length < BATCH_SIZE) break;
     } while (true);
-    console.log(`[SeedLikes] Step 1 done — ${userKeyCount} user Hashes written`);
+    console.log(`[SeedLikes] Step 1 done — ${userKeyCount} user Sets written`);
 
     // ── Step 2: per-post like count ──────────────────────────────────────────
     console.log('[SeedLikes] Step 2/3 — writing per-post like counts...');

--- a/scripts/syncEngagementToRedis.js
+++ b/scripts/syncEngagementToRedis.js
@@ -1,15 +1,14 @@
 /**
- * Sync script: writes per-post like counts and comment counts from DB → Redis.
+ * Full engagement sync: writes like counts, comment counts, per-user liked Sets,
+ * and per-post likedBy Hashes from DB → Redis.
  *
- * Run manually:  node src/scripts/syncEngagementToRedis.js
- * Or import and call syncEngagementToRedis() programmatically.
+ * Run manually:  node scripts/syncEngagementToRedis.js
  *
  * What it writes:
- *   fn:post:{postId}:likes:count    = N  (TTL: POST_ENGAGEMENT)
- *   fn:post:{postId}:comments:count = N  (TTL: POST_ENGAGEMENT)
- *
- * Like counts come from the Like collection (aggregate).
- * Comment counts come from the Comment collection (aggregate, top-level only).
+ *   fn:post:{postId}:likes:count    String  N               (TTL: POST_ENGAGEMENT)
+ *   fn:post:{postId}:comments:count String  N               (TTL: POST_ENGAGEMENT)
+ *   fn:user:{userId}:liked          Set     members=postIds (TTL: POST_LIKE_STATUS)
+ *   fn:post:{postId}:likedby        Hash    field=userId value=JSON profile (TTL: POST_ENGAGEMENT)
  */
 
 import 'dotenv/config';
@@ -17,40 +16,146 @@ import connectDB from '../src/db/index.js';
 import { redisClient, RedisKeys, RedisTTL } from '../src/config/redis.config.js';
 import Like from '../src/models/like.models.js';
 import Comment from '../src/models/comment.models.js';
+import { User } from '../src/models/user.models.js';
 
-const TTL = RedisTTL.POST_ENGAGEMENT;
+const ENG_TTL  = RedisTTL.POST_ENGAGEMENT;
+const LIKE_TTL = RedisTTL.POST_LIKE_STATUS;
+const BATCH_SIZE   = 1000;
+const MAX_LIKEDBY  = 50;
+const POST_CHUNK   = 200;
 
 export async function syncEngagementToRedis() {
     console.log('[SyncEngagement] Starting DB → Redis sync...');
 
-    // ── Like counts ──────────────────────────────────────────────────────────
+    // ── 1. Like counts ───────────────────────────────────────────────────────
+    console.log('[SyncEngagement] Step 1/4 — writing per-post like counts...');
     const likeCounts = await Like.aggregate([
         { $match: { postId: { $ne: null } } },
         { $group: { _id: '$postId', count: { $sum: 1 } } },
     ]);
 
-    // ── Comment counts (top-level only) ─────────────────────────────────────
+    {
+        const pipeline = redisClient.pipeline();
+        for (const { _id: postId, count } of likeCounts) {
+            if (!postId) continue;
+            pipeline.set(RedisKeys.postLikesCount(postId.toString()), count, 'EX', ENG_TTL);
+        }
+        await pipeline.exec();
+    }
+    console.log(`[SyncEngagement] Step 1 done — ${likeCounts.length} like-count keys`);
+
+    // ── 2. Comment counts (top-level only) ───────────────────────────────────
+    console.log('[SyncEngagement] Step 2/4 — writing per-post comment counts...');
     const commentCounts = await Comment.aggregate([
         { $match: { parentCommentId: null } },
         { $group: { _id: '$postId', count: { $sum: 1 } } },
     ]);
 
-    // Merge into a single pipeline write
-    const pipeline = redisClient.pipeline();
+    {
+        const pipeline = redisClient.pipeline();
+        for (const { _id: postId, count } of commentCounts) {
+            if (!postId) continue;
+            pipeline.set(RedisKeys.postCommentsCount(postId.toString()), count, 'EX', ENG_TTL);
+        }
+        await pipeline.exec();
+    }
+    console.log(`[SyncEngagement] Step 2 done — ${commentCounts.length} comment-count keys`);
 
-    for (const { _id: postId, count } of likeCounts) {
-        if (!postId) continue;
-        pipeline.set(RedisKeys.postLikesCount(postId.toString()), count, 'EX', TTL);
+    // ── 3. Per-user liked Sets ────────────────────────────────────────────────
+    // fn:user:{userId}:liked  →  Set{ postId, ... }
+    console.log('[SyncEngagement] Step 3/4 — writing per-user liked Sets...');
+    let cursor = null;
+    let userKeyCount = 0;
+
+    do {
+        const query = Like.find({ postId: { $ne: null } }).select('userId postId').lean();
+        if (cursor) query.where('_id').gt(cursor);
+        const batch = await query.limit(BATCH_SIZE);
+        if (!batch.length) break;
+        cursor = batch[batch.length - 1]._id;
+
+        const byUser = new Map();
+        for (const { userId, postId } of batch) {
+            if (!userId || !postId) continue;
+            const uid = userId.toString();
+            if (!byUser.has(uid)) byUser.set(uid, []);
+            byUser.get(uid).push(postId.toString());
+        }
+
+        const pipeline = redisClient.pipeline();
+        for (const [uid, postIds] of byUser) {
+            const setKey = RedisKeys.userLikedSet(uid);
+            pipeline.sadd(setKey, ...postIds);
+            pipeline.expire(setKey, LIKE_TTL);
+            userKeyCount++;
+        }
+        await pipeline.exec();
+        if (batch.length < BATCH_SIZE) break;
+    } while (true);
+
+    console.log(`[SyncEngagement] Step 3 done — ${userKeyCount} user liked Sets`);
+
+    // ── 4. Per-post likedBy Hashes ────────────────────────────────────────────
+    // fn:post:{postId}:likedby  →  { [userId]: JSON{profile + likedAt} }
+    // Capped at MAX_LIKEDBY newest likers per post.
+    console.log('[SyncEngagement] Step 4/4 — writing per-post likedBy Hashes...');
+    const postIds = likeCounts.map(c => c._id).filter(Boolean);
+    let likedByKeyCount = 0;
+
+    for (let i = 0; i < postIds.length; i += POST_CHUNK) {
+        const chunk = postIds.slice(i, i + POST_CHUNK);
+
+        const dbLikes = await Like.aggregate([
+            { $match: { postId: { $in: chunk } } },
+            { $sort: { createdAt: -1 } },
+            {
+                $group: {
+                    _id: '$postId',
+                    likers: { $push: { userId: '$userId', createdAt: '$createdAt' } },
+                },
+            },
+            {
+                $project: { likers: { $slice: ['$likers', MAX_LIKEDBY] } },
+            },
+        ]);
+
+        const allUserIds = [...new Set(
+            dbLikes.flatMap(g => g.likers.map(l => l.userId.toString()))
+        )];
+
+        const profiles = allUserIds.length
+            ? await User.find({ _id: { $in: allUserIds } }, 'username fullName profileImageUrl').lean()
+            : [];
+        const profileMap = new Map(profiles.map(u => [u._id.toString(), u]));
+
+        const pipeline = redisClient.pipeline();
+        for (const { _id: postId, likers } of dbLikes) {
+            const likedByKey = RedisKeys.postLikedBy(postId.toString());
+            const args = [likedByKey];
+            for (const { userId, createdAt } of likers) {
+                const uid = userId.toString();
+                const profile = profileMap.get(uid);
+                if (!profile) continue;
+                args.push(uid, JSON.stringify({
+                    _id: uid,
+                    userId: uid,
+                    username: profile.username,
+                    fullName: profile.fullName,
+                    profileImageUrl: profile.profileImageUrl,
+                    likedAt: createdAt ? new Date(createdAt).getTime() : Date.now(),
+                }));
+            }
+            if (args.length > 1) {
+                pipeline.hset(...args);
+                pipeline.expire(likedByKey, ENG_TTL);
+                likedByKeyCount++;
+            }
+        }
+        await pipeline.exec();
     }
 
-    for (const { _id: postId, count } of commentCounts) {
-        if (!postId) continue;
-        pipeline.set(RedisKeys.postCommentsCount(postId.toString()), count, 'EX', TTL);
-    }
-
-    await pipeline.exec();
-
-    console.log(`[SyncEngagement] Done — ${likeCounts.length} like-count keys, ${commentCounts.length} comment-count keys written`);
+    console.log(`[SyncEngagement] Step 4 done — ${likedByKeyCount} likedBy Hashes`);
+    console.log('[SyncEngagement] Sync complete.');
 }
 
 if (process.argv[1].includes('syncEngagementToRedis')) {

--- a/src/controllers/comment.controllers.js
+++ b/src/controllers/comment.controllers.js
@@ -73,7 +73,7 @@ export const createComment = asyncHandler(async (req, res) => {
 
     // Populate user and replyToUser before returning
     const populatedComment = await Comment.findById(comment._id)
-        .populate('userId', 'username fullName profileImageUrl bio location isBusinessProfile')
+        .populate('userId', 'username fullName profileImageUrl isBusinessProfile')
         .populate('replyToUserId', 'username fullName profileImageUrl isBusinessProfile')
         .lean();
 
@@ -99,7 +99,7 @@ export const getCommentsByPost = asyncHandler(async (req, res) => {
         Comment.find({ postId, parentCommentId: null, isDeleted: false })
             .populate({
                 path: 'userId',
-                select: 'username fullName profileImageUrl bio location isBusinessProfile',
+                select: 'username fullName profileImageUrl isBusinessProfile',
                 match: { accountStatus: 'active', isDeleted: { $ne: true } }
             })
             .populate('replyToUserId', 'username fullName profileImageUrl isBusinessProfile')
@@ -215,7 +215,7 @@ export const getCommentById = asyncHandler(async (req, res) => {
     const skip = (pageNum - 1) * pageLimit;
 
     const comment = await Comment.findById(commentId)
-        .populate('userId', 'username fullName profileImageUrl bio location')
+        .populate('userId', 'username fullName profileImageUrl')
         .populate('replyToUserId', 'username fullName profileImageUrl')
         .lean();
     if (!comment || comment.isDeleted) throw new ApiError(404, "Comment not found");
@@ -237,7 +237,7 @@ export const getCommentById = asyncHandler(async (req, res) => {
                 ],
                 isDeleted: false
             })
-                .populate('userId', 'username fullName profileImageUrl bio location')
+                .populate('userId', 'username fullName profileImageUrl')
                 .populate('replyToUserId', 'username fullName profileImageUrl')
                 .sort({ createdAt: 1 })
                 .skip(skip)
@@ -261,7 +261,7 @@ export const getCommentById = asyncHandler(async (req, res) => {
 
         // Fetch and sort all descendants, then paginate
         replies = await Comment.find({ _id: { $in: allDescendantIds } })
-            .populate('userId', 'username fullName profileImageUrl bio location')
+            .populate('userId', 'username fullName profileImageUrl')
             .populate('replyToUserId', 'username fullName profileImageUrl')
             .sort({ createdAt: 1 })
             .skip(skip)
@@ -388,7 +388,7 @@ export const updateComment = asyncHandler(async (req, res) => {
         { content, isEdited: true },
         { new: true }
     )
-        .populate('userId', 'username fullName profileImageUrl bio location isBusinessProfile')
+        .populate('userId', 'username fullName profileImageUrl isBusinessProfile')
         .populate('replyToUserId', 'username fullName profileImageUrl isBusinessProfile')
         .lean();
     if (!comment || comment.isDeleted) throw new ApiError(404, "Comment not found");

--- a/src/controllers/homeFeed.controllers.js
+++ b/src/controllers/homeFeed.controllers.js
@@ -56,18 +56,27 @@ export const getHomeFeed = asyncHandler(async (req, res) => {
             if (cached?.data?.feed?.length) {
                 const cachedPosts = cached.data.feed;
                 const cachedPostIds = cachedPosts.map(p => p._id);
-                const [likedSet, likeCountMap] = await Promise.all([
+                const [likedSet, likeCountMap, likedByUsersMap] = await Promise.all([
                     userId ? batchIsLikedByUser(userId, cachedPostIds) : Promise.resolve(new Set()),
                     batchGetLikesCount(cachedPosts),
+                    batchGetLikedByUsers(cachedPostIds),
                 ]);
-                cached.data.feed = cachedPosts.map(post => ({
-                    ...post,
-                    engagement: {
-                        ...post.engagement,
-                        likes: likeCountMap.get(post._id.toString()) ?? post.engagement?.likes ?? 0,
-                    },
-                    isLikedBy: likedSet.has(post._id.toString()),
-                }));
+
+                cached.data.feed = cachedPosts.map(post => {
+                    const idStr = post._id.toString();
+                    const likedByUsers = likedByUsersMap.get(idStr) || [];
+                    const preview = getLikedByPreview(likedByUsers, userId);
+                    return {
+                        ...post,
+                        engagement: {
+                            ...post.engagement,
+                            likes: likeCountMap.get(idStr) ?? post.engagement?.likes ?? 0,
+                        },
+                        isLikedBy: likedSet.has(idStr),
+                        likedBy: likedByUsers,
+                        likedByPreview: preview.likedByText ? { text: preview.likedByText } : null,
+                    };
+                });
             }
             return res.status(200).json(cached);
         }
@@ -316,27 +325,10 @@ export const getHomeFeed = asyncHandler(async (req, res) => {
         });
 
         // ✅ 5. Format final response
-        // Get user's followers and following for "Liked by" preview (reuse from earlier fetch if available)
-        let userFollowing = [];
-        let userFollowers = [];
-        if (userId) {
-            const user = await User.findById(userId)
-                .select('following followers')
-                .lean();
-            userFollowing = user?.following || [];
-            userFollowers = user?.followers || [];
-        }
-
         const feedData = posts.map(post => {
             const postIdStr = post._id.toString();
             const likedByUsers = likesByPost.get(postIdStr) || [];
-
-            const likedByPreview = getLikedByPreview(
-                likedByUsers,
-                userId,
-                userFollowing,
-                userFollowers
-            );
+            const preview = getLikedByPreview(likedByUsers, userId);
 
             return {
                 ...post,
@@ -347,11 +339,7 @@ export const getHomeFeed = asyncHandler(async (req, res) => {
                 comments: commentsByPost.get(postIdStr) || [],
                 isLikedBy: likedPostIds.has(postIdStr),
                 likedBy: likedByUsers,
-                likedByPreview: likedByPreview.likedByText ? {
-                    text: likedByPreview.likedByText,
-                    previewUser: likedByPreview.previewUser,
-                    othersCount: likedByPreview.othersCount
-                } : null
+                likedByPreview: preview.likedByText ? { text: preview.likedByText } : null,
             };
         });
         // Enrich posts with review/rating data

--- a/src/controllers/like.controllers.js
+++ b/src/controllers/like.controllers.js
@@ -6,7 +6,7 @@ import Post from "../models/userPost.models.js";
 import Comment from "../models/comment.models.js";
 import { createLikeNotification, createUnlikeNotification } from "./notification.controllers.js";
 import { redisClient, RedisKeys, RedisTTL } from "../config/redis.config.js";
-import { onPostLiked, onPostUnliked } from "../utils/postEngagement.utils.js";
+import { onPostLiked, onPostUnliked, batchIsLikedByUser } from "../utils/postEngagement.utils.js";
 import { likeQueue } from "../queues/likeQueue.js";
 
 const ENGAGEMENT_TTL = RedisTTL.POST_ENGAGEMENT;
@@ -33,18 +33,14 @@ async function ensureLikesCount(postId, delta) {
 
 /**
  * Check whether a user has liked a specific post.
- * Set-based: EXISTS + SISMEMBER on fn:user:{userId}:liked.
- * Key exists → SISMEMBER is authoritative. Key missing → DB fallback.
+ * Delegates to batchIsLikedByUser which seeds the full user liked Set from DB
+ * on a cache miss, ensuring the check is always authoritative (no stale misses
+ * when the Set has expired but the Like document hasn't been written to DB yet).
  */
 async function getLikeStatus(userId, postId) {
     try {
-        const setKey = RedisKeys.userLikedSet(userId.toString());
-        const [[, exists], [, isMember]] = await redisClient.pipeline()
-            .exists(setKey)
-            .sismember(setKey, postId.toString())
-            .exec();
-        if (!exists) return !!(await Like.exists({ userId, postId }));
-        return isMember === 1;
+        const likedSet = await batchIsLikedByUser(userId, [postId]);
+        return likedSet.has(postId.toString());
     } catch {
         return !!(await Like.exists({ userId, postId }));
     }
@@ -160,7 +156,7 @@ export const likePost = asyncHandler(async (req, res) => {
     const alreadyLiked = await getLikeStatus(userId, postId);
     if (alreadyLiked) throw new ApiError(409, "You have already liked this post");
 
-    const redisOk = await onPostLiked(userId, postId, {
+    const result = await onPostLiked(userId, postId, {
         username: req.user.username,
         fullName: req.user.fullName,
         profileImageUrl: req.user.profileImageUrl,
@@ -180,10 +176,12 @@ export const likePost = asyncHandler(async (req, res) => {
         }
     }).catch(() => {});
 
-    const [{ users: likedBy, hasMore }, likesCount] = await Promise.all([
-        getLikedByList(postId, { includeUser: redisOk ? req.user : null }),
-        ensureLikesCount(postId, +1),
+    const [{ users: likedBy, hasMore }] = await Promise.all([
+        getLikedByList(postId, { includeUser: result.ok ? req.user : null }),
     ]);
+
+    // Lua returns the new count; fall back to DB-seed only if Lua failed entirely
+    const likesCount = result.count ?? await ensureLikesCount(postId, +1);
 
     return res.status(200).json(new ApiResponse(200, {
         likedBy,
@@ -202,7 +200,7 @@ export const unlikePost = asyncHandler(async (req, res) => {
     const isLiked = await getLikeStatus(userId, postId);
     if (!isLiked) throw new ApiError(404, "You have not liked this post");
 
-    const redisOk = await onPostUnliked(userId, postId);
+    const result = await onPostUnliked(userId, postId);
 
     // Enqueue DB sync job
     likeQueue.add('like-event', {
@@ -218,10 +216,11 @@ export const unlikePost = asyncHandler(async (req, res) => {
         }
     }).catch(() => {});
 
-    const [{ users: likedBy, hasMore }, likesCount] = await Promise.all([
-        getLikedByList(postId, { excludeUserId: redisOk ? userId : null }),
-        ensureLikesCount(postId, -1),
+    const [{ users: likedBy, hasMore }] = await Promise.all([
+        getLikedByList(postId, { excludeUserId: result.ok ? userId : null }),
     ]);
+
+    const likesCount = result.count ?? await ensureLikesCount(postId, -1);
 
     return res.status(200).json(new ApiResponse(200, {
         likedBy,

--- a/src/controllers/post.controllers.js
+++ b/src/controllers/post.controllers.js
@@ -427,58 +427,43 @@ export const getPostById = asyncHandler(async (req, res) => {
         }
     }
 
-    // Fetch likes for this post and populate user details
-    const likes = await Like.find({ postId: postId }).lean();
-    const likedByUserIds = likes.map(like => like.userId.toString());
+    // Read likedBy from Redis Hash + check current user's like status — both Redis-first
+    const [likedByMap, likedSet, likeCountMap] = await Promise.all([
+        batchGetLikedByUsers([postId]),
+        currentUser ? batchIsLikedByUser(currentUser._id, [postId]) : Promise.resolve(new Set()),
+        batchGetLikesCount([post]),
+    ]);
 
-    // Inject current user if their like is deferred in Redis (not yet synced to DB).
-    // batchIsLikedByUser is Redis-first with automatic DB fallback on Redis failure.
-    if (currentUser) {
+    const postIdStr = postId.toString();
+    let likedByUsers = likedByMap.get(postIdStr) || [];
+    const currentUserLiked = currentUser ? likedSet.has(postIdStr) : false;
+
+    // Inject current user at front if their like is deferred (not yet in the likedBy cache)
+    if (currentUserLiked) {
         const curIdStr = currentUser._id.toString();
-        if (!likedByUserIds.includes(curIdStr)) {
-            const likedSet = await batchIsLikedByUser(currentUser._id, [postId]);
-            if (likedSet.has(postId.toString())) likedByUserIds.unshift(curIdStr);
+        if (!likedByUsers.find(u => (u._id || u.userId)?.toString() === curIdStr)) {
+            likedByUsers = [{
+                _id: curIdStr,
+                userId: curIdStr,
+                username: currentUser.username,
+                fullName: currentUser.fullName,
+                profileImageUrl: currentUser.profileImageUrl,
+                isVerified: currentUser.isVerified,
+            }, ...likedByUsers];
         }
     }
 
-    // Fetch user details for all users who liked the post
-    let likedByUsers = [];
-    if (likedByUserIds.length > 0) {
-        likedByUsers = await Post.db.model('User').find(
-            { _id: { $in: likedByUserIds } },
-            'username fullName profileImageUrl isVerified'
-        ).lean();
-    }
-
-    // Add likedBy array and isLikedBy flag to the post
     post.likedBy = likedByUsers;
-    post.isLikedBy = currentUser ? likedByUserIds.includes(currentUser._id.toString()) : false;
-
-    // Override stale DB count with Redis-accurate count (DB is only updated by 4h cron)
-    const likeCountMap = await batchGetLikesCount([post]);
+    post.isLikedBy = currentUserLiked;
     post.engagement = {
         ...(post.engagement || {}),
-        likes: likeCountMap.get(postId.toString()) ?? post.engagement?.likes ?? 0,
+        likes: likeCountMap.get(postIdStr) ?? post.engagement?.likes ?? 0,
     };
 
-    // Add "Liked by" preview
+    // Add "Liked by" preview text
     if (currentUser) {
-        const user = await User.findById(currentUser._id).select('following followers').lean();
-        const userFollowing = user?.following || [];
-        const userFollowers = user?.followers || [];
-
-        const likedByPreview = getLikedByPreview(
-            likedByUsers,
-            currentUser._id.toString(),
-            userFollowing,
-            userFollowers
-        );
-
-        post.likedByPreview = likedByPreview.likedByText ? {
-            text: likedByPreview.likedByText,
-            previewUser: likedByPreview.previewUser,
-            othersCount: likedByPreview.othersCount
-        } : null;
+        const preview = getLikedByPreview(likedByUsers, currentUser._id.toString());
+        post.likedByPreview = preview.likedByText ? { text: preview.likedByText } : null;
     }
 
     // Add subscription badge to post author
@@ -1446,25 +1431,10 @@ export const getMyPosts = asyncHandler(async (req, res) => {
         post.engagement = { ...(post.engagement || {}), likes: likeCountMap.get(idStr) ?? post.engagement?.likes ?? 0 };
     });
 
-    // Add "Liked by" preview to each post
-    const currentUserFollowData = await User.findById(userId).select('following followers').lean();
-    const userFollowing = currentUserFollowData?.following || [];
-    const userFollowers = currentUserFollowData?.followers || [];
-
+    // Add "Liked by" preview text to each post
     postsWithThumbnails.forEach(post => {
-        const likedByUsers = post.likedBy || [];
-        const likedByPreview = getLikedByPreview(
-            likedByUsers,
-            currentUserId,
-            userFollowing,
-            userFollowers
-        );
-
-        post.likedByPreview = likedByPreview.likedByText ? {
-            text: likedByPreview.likedByText,
-            previewUser: likedByPreview.previewUser,
-            othersCount: likedByPreview.othersCount
-        } : null;
+        const preview = getLikedByPreview(post.likedBy || [], currentUserId);
+        post.likedByPreview = preview.likedByText ? { text: preview.likedByText } : null;
     });
 
     // Enrich posts with review/rating data
@@ -1660,26 +1630,11 @@ export const getUserProfilePosts = asyncHandler(async (req, res) => {
             post.engagement = { ...(post.engagement || {}), likes: likeCountMap.get(idStr) ?? post.engagement?.likes ?? 0 };
         });
 
-        // Add "Liked by" preview to each post
+        // Add "Liked by" preview text to each post
         if (currentUser) {
-            const currentUserData = await User.findById(currentUser._id).select('following followers').lean();
-            const userFollowing = currentUserData?.following || [];
-            const userFollowers = currentUserData?.followers || [];
-
             postsAfterBusinessFilter.forEach(post => {
-                const likedByUsers = post.likedBy || [];
-                const likedByPreview = getLikedByPreview(
-                    likedByUsers,
-                    currentUserId,
-                    userFollowing,
-                    userFollowers
-                );
-
-                post.likedByPreview = likedByPreview.likedByText ? {
-                    text: likedByPreview.likedByText,
-                    previewUser: likedByPreview.previewUser,
-                    othersCount: likedByPreview.othersCount
-                } : null;
+                const preview = getLikedByPreview(post.likedBy || [], currentUserId);
+                post.likedByPreview = preview.likedByText ? { text: preview.likedByText } : null;
             });
         }
 

--- a/src/controllers/reel.controllers.js
+++ b/src/controllers/reel.controllers.js
@@ -8,7 +8,7 @@ import { enrichWithRatings } from "../utils/reviewUtils.js";
 import { addBadgesToNestedUsers } from "../utils/userBadge.utils.js";
 import { getLikedByPreview } from "../utils/likedByPreview.utils.js";
 import Like from "../models/like.models.js";
-import { batchIsLikedByUser, batchGetLikedByUsers, batchGetLikesCount, batchGetCommentsCount, batchGetLikedByUserIds } from "../utils/postEngagement.utils.js";
+import { batchIsLikedByUser, batchGetLikedByUsers, batchGetLikesCount, batchGetCommentsCount } from "../utils/postEngagement.utils.js";
 import mongoose from "mongoose";
 import { getFollowStatus } from "../utils/followEngagement.utils.js";
 
@@ -167,33 +167,27 @@ export const getSuggestedReels = asyncHandler(async (req, res) => {
             const cachedData = cache.reels.data;
             if (currentUserId && cachedData.reels?.length) {
                 const reelIds = cachedData.reels.map(r => r._id);
-                const [likedSet, likeCountMap, commentCountMap, likedByIdsMap] = await Promise.all([
+                const [likedSet, likeCountMap, commentCountMap, likedByUsersMap] = await Promise.all([
                     batchIsLikedByUser(currentUserId, reelIds),
                     batchGetLikesCount(cachedData.reels),
                     batchGetCommentsCount(cachedData.reels),
-                    batchGetLikedByUserIds(reelIds),
+                    batchGetLikedByUsers(reelIds),
                 ]);
                 const userIdStr = currentUserId.toString();
-                for (const [idStr, userIds] of likedByIdsMap) {
-                    if (likedSet.has(idStr) && !userIds.includes(userIdStr)) userIds.push(userIdStr);
-                }
-                const allLikerIds = [...new Set([...likedByIdsMap.values()].flat())];
-                const likerProfiles = allLikerIds.length
-                    ? await User.find({ _id: { $in: allLikerIds } }, 'username fullName profileImageUrl').lean()
-                    : [];
-                const pMap = new Map(likerProfiles.map(u => [u._id.toString(), u]));
-                const me = await User.findById(currentUserId).select('following followers').lean();
-                const following = me?.following || [], followers = me?.followers || [];
                 const updatedReels = cachedData.reels.map(r => {
                     const rid = r._id.toString();
-                    const likedByUsers = (likedByIdsMap.get(rid) || []).map(uid => pMap.get(uid)).filter(Boolean);
-                    const preview = getLikedByPreview(likedByUsers, currentUserId, following, followers);
+                    let likedByUsers = likedByUsersMap.get(rid) || [];
+                    // Inject viewer if their like is deferred in the cache
+                    if (likedSet.has(rid) && !likedByUsers.find(u => (u.userId || u._id?.toString()) === userIdStr)) {
+                        likedByUsers = [{ _id: userIdStr, userId: userIdStr, username: req.user?.username, fullName: req.user?.fullName, profileImageUrl: req.user?.profileImageUrl }, ...likedByUsers];
+                    }
+                    const preview = getLikedByPreview(likedByUsers, currentUserId);
                     return {
                         ...r,
                         engagement: { ...(r.engagement || {}), likes: likeCountMap.get(rid) ?? r.engagement?.likes ?? 0, comments: commentCountMap.get(rid) ?? r.engagement?.comments ?? 0 },
                         isLikedBy: likedSet.has(rid),
                         likedBy: likedByUsers,
-                        likedByPreview: preview.likedByText ? { text: preview.likedByText, previewUser: preview.previewUser, othersCount: preview.othersCount } : null,
+                        likedByPreview: preview.likedByText ? { text: preview.likedByText } : null,
                     };
                 });
                 return res.status(200).json(new ApiResponse(200, { ...cachedData, reels: updatedReels }, "Reels fetched from cache"));
@@ -409,26 +403,20 @@ export const getSuggestedReels = asyncHandler(async (req, res) => {
                 batchGetLikesCount(reels),
             ]);
 
-            // Get viewer's social graph for preview text
-            let userFollowing = [];
-            let userFollowers = [];
+            // Inject current user into likedBy if their like is deferred
             if (currentUserId) {
                 const userIdStr = currentUserId.toString();
-                for (const [idStr, userIds] of likesByReel) {
-                    if (likedReelSet.has(idStr) && !userIds.includes(userIdStr)) userIds.push(userIdStr);
+                for (const [idStr, users] of likesByReel) {
+                    if (likedReelSet.has(idStr) && !users.find(u => (u.userId || u._id?.toString()) === userIdStr)) {
+                        users.unshift({ _id: userIdStr, userId: userIdStr });
+                    }
                 }
             }
 
             reels = reels.map(reel => {
                 const reelIdStr = reel._id.toString();
                 const likedByUsers = likesByReel.get(reelIdStr) || [];
-
-                const likedByPreview = getLikedByPreview(
-                    likedByUsers,
-                    currentUserId,
-                    userFollowing,
-                    userFollowers
-                );
+                const preview = getLikedByPreview(likedByUsers, currentUserId);
 
                 return {
                     ...reel,
@@ -438,11 +426,7 @@ export const getSuggestedReels = asyncHandler(async (req, res) => {
                     },
                     isLikedBy: likedReelSet.has(reelIdStr),
                     likedBy: likedByUsers,
-                    likedByPreview: likedByPreview.likedByText ? {
-                        text: likedByPreview.likedByText,
-                        previewUser: likedByPreview.previewUser,
-                        othersCount: likedByPreview.othersCount
-                    } : null,
+                    likedByPreview: preview.likedByText ? { text: preview.likedByText } : null,
                 };
             });
 

--- a/src/controllers/searchAllContent.controllers.js
+++ b/src/controllers/searchAllContent.controllers.js
@@ -518,18 +518,10 @@ export const searchAllContent = async (req, res) => {
             batchGetLikesCount(paginatedContent),
         ]);
 
-        let userFollowing = [];
-        let userFollowers = [];
-        if (currentUserId) {
-            const viewer = await User.findById(currentUserId).select('following followers').lean();
-            userFollowing = viewer?.following || [];
-            userFollowers = viewer?.followers || [];
-        }
-
         const stitchedContent = paginatedContent.map(item => {
             const idStr = item._id.toString();
             const likedByUsers = likedByMap.get(idStr) || [];
-            const preview = getLikedByPreview(likedByUsers, currentUserId, userFollowing, userFollowers);
+            const preview = getLikedByPreview(likedByUsers, currentUserId);
             return {
                 ...item,
                 engagement: {
@@ -538,11 +530,7 @@ export const searchAllContent = async (req, res) => {
                 },
                 isLikedBy: likedSet.has(idStr),
                 likedBy: likedByUsers,
-                likedByPreview: preview.likedByText ? {
-                    text: preview.likedByText,
-                    previewUser: preview.previewUser,
-                    othersCount: preview.othersCount,
-                } : null,
+                likedByPreview: preview.likedByText ? { text: preview.likedByText } : null,
             };
         });
 

--- a/src/controllers/share.controllers.js
+++ b/src/controllers/share.controllers.js
@@ -4,7 +4,6 @@ import { ApiError } from "../utils/ApiError.js";
 import { ApiResponse } from "../utils/ApiResponse.js";
 import Post from "../models/userPost.models.js";
 import Like from "../models/like.models.js";
-import Comment from "../models/comment.models.js";
 import PostInteraction from "../models/postInteraction.models.js";
 import Follower from "../models/follower.models.js";
 import { canViewPost } from "../utils/postPrivacy.js";
@@ -244,9 +243,6 @@ export const getSharedPost = asyncHandler(async (req, res) => {
     }
   }
 
-  // Fetch engagement data
-  const comments = await Comment.find({ postId }).lean();
-
   if (viewer) {
     const likedSet = await batchIsLikedByUser(viewer._id, [postId]);
     post.isLikedBy = likedSet.has(postId.toString());
@@ -384,13 +380,9 @@ export const getSharedReel = asyncHandler(async (req, res) => {
     }
   }
 
-  // Fetch engagement data
-  const likes = await Like.find({ postId }).lean();
-  const comments = await Comment.find({ postId }).lean();
-
-  const likedByUserIds = likes.map((like) => like.userId.toString());
   if (viewer) {
-    post.isLikedBy = likedByUserIds.includes(viewer._id.toString());
+    const likedSet = await batchIsLikedByUser(viewer._id, [postId]);
+    post.isLikedBy = likedSet.has(postId.toString());
   }
 
   // Get top 3 users who liked

--- a/src/controllers/switch.controllers.js
+++ b/src/controllers/switch.controllers.js
@@ -3,8 +3,8 @@ import { ApiResponse } from "../utils/ApiResponse.js";
 import Post from "../models/userPost.models.js";
 import Story from "../models/story.models.js";
 import TaggedUser from "../models/taggedUser.models.js";
-import Like from "../models/like.models.js";
 import { asyncHandler } from "../utils/asyncHandler.js";
+import { batchIsLikedByUser } from "../utils/postEngagement.utils.js";
 
 const allowedTabs = ["photos", "reels", "videos", "tagged", "stories"];
 const postProjection = {
@@ -127,11 +127,10 @@ export const getProfileTabContent = asyncHandler(async (req, res) => {
     // Add isLikedBy for posts (not stories)
     if (["photos", "reels", "videos", "tagged"].includes(tab) && data.length > 0 && currentUserId) {
         const postIds = data.map(post => post._id);
-        const likes = await Like.find({ postId: { $in: postIds }, userId: currentUserId }).lean();
-        const likedPostIds = new Set(likes.map(like => like.postId.toString()));
+        const likedSet = await batchIsLikedByUser(currentUserId, postIds);
         data = data.map(post => ({
             ...post,
-            isLikedBy: likedPostIds.has(post._id.toString())
+            isLikedBy: likedSet.has(post._id.toString())
         }));
     }
 

--- a/src/controllers/user.controllers.js
+++ b/src/controllers/user.controllers.js
@@ -1371,7 +1371,6 @@ const getOtherUserProfile = asyncHandler(async (req, res) => {
     const userWithCounts = {
         _id: targetUser._id,
         username: targetUser.username,
-        email: targetUser.email,
         fullName: targetUser.fullName,
         phoneNumber: targetUser.isPhoneNumberHidden ? null : (targetUser.phoneNumber || ""),
         address: targetUser.isAddressHidden ? null : (targetUser.address || ""),
@@ -1381,8 +1380,6 @@ const getOtherUserProfile = asyncHandler(async (req, res) => {
         businessId: businessId,
         isEmailVerified: targetUser.isEmailVerified,
         isPhoneVerified: targetUser.isPhoneVerified,
-        isPhoneNumberHidden: targetUser.isPhoneNumberHidden,
-        isAddressHidden: targetUser.isAddressHidden,
         isContentVisible: targetUser.isBusinessProfile ? isContentVisible : true,
         contentVisibilityMessage: targetUser.isBusinessProfile && !isContentVisible
             ? 'Content is currently hidden. Activate your payment plan to make posts visible.'
@@ -1708,14 +1705,14 @@ const getBlockedUsers = asyncHandler(async (req, res) => {
     const blockerId = req.user._id;
 
     const blockedUsers = await Block.find({ blockerId })
-        .populate('blockedId', 'fullName username profileImage')
+        .populate('blockedId', 'fullName username profileImageUrl')
         .sort({ createdAt: -1 });
 
     const formattedBlockedUsers = blockedUsers.map(block => ({
         blockedUserId: block.blockedId._id,
         fullName: block.blockedId.fullName,
         username: block.blockedId.username,
-        profileImage: block.blockedId.profileImage,
+        profileImageUrl: block.blockedId.profileImageUrl,
         blockedAt: block.createdAt,
         reason: block.reason
     }));

--- a/src/utils/postEngagement.utils.js
+++ b/src/utils/postEngagement.utils.js
@@ -17,7 +17,12 @@ const PREVIEW_LIMIT = 20;
 // ---------------------------------------------------------------------------
 
 // KEYS: [countKey, userLikedSetKey, likedByKey]
-// ARGV: [postId, userId, userDataJSON, engTTL, likeTTL]
+// ARGV: [postId, userId, userDataJSON, engTTL, likeTTL, seedCount]
+//
+// seedCount: DB like count passed by caller; used to initialise countKey via SET NX
+// so the key always exists before INCR, preventing the race where two concurrent
+// likes both find the key missing, both skip the increment, and the count ends up
+// one (or more) short.
 const LIKE_LUA = `
 local countKey   = KEYS[1]
 local userSetKey = KEYS[2]
@@ -27,19 +32,19 @@ local userId     = ARGV[2]
 local userData   = ARGV[3]
 local engTTL     = tonumber(ARGV[4])
 local likeTTL    = tonumber(ARGV[5])
+local seedCount  = ARGV[6]
+redis.call('set', countKey, seedCount, 'EX', engTTL, 'NX')
+local newCount = tonumber(redis.call('incr', countKey))
+redis.call('expire', countKey, engTTL)
 redis.call('sadd', userSetKey, postId)
 redis.call('expire', userSetKey, likeTTL)
-if redis.call('exists', countKey) == 1 then
-  redis.call('incr', countKey)
-  redis.call('expire', countKey, engTTL)
-end
 redis.call('hset', likedByKey, userId, userData)
 redis.call('expire', likedByKey, engTTL)
-return 1
+return newCount
 `;
 
 // KEYS: [countKey, userLikedSetKey, likedByKey]
-// ARGV: [postId, userId, engTTL, likeTTL]
+// ARGV: [postId, userId, engTTL, likeTTL, seedCount]
 const UNLIKE_LUA = `
 local countKey   = KEYS[1]
 local userSetKey = KEYS[2]
@@ -48,15 +53,19 @@ local postId     = ARGV[1]
 local userId     = ARGV[2]
 local engTTL     = tonumber(ARGV[3])
 local likeTTL    = tonumber(ARGV[4])
-redis.call('srem', userSetKey, postId)
-redis.call('expire', userSetKey, likeTTL)
-if redis.call('exists', countKey) == 1 then
-  local c = redis.call('decr', countKey)
-  if c < 0 then redis.call('set', countKey, '0') end
+local seedCount  = ARGV[5]
+redis.call('set', countKey, seedCount, 'EX', engTTL, 'NX')
+local c = tonumber(redis.call('decr', countKey))
+if c < 0 then
+  redis.call('set', countKey, '0', 'EX', engTTL)
+  c = 0
+else
   redis.call('expire', countKey, engTTL)
 end
+redis.call('srem', userSetKey, postId)
+redis.call('expire', userSetKey, likeTTL)
 redis.call('hdel', likedByKey, userId)
-return 1
+return c
 `;
 
 // ---------------------------------------------------------------------------
@@ -451,18 +460,10 @@ export async function stitchEngagement(userId, items, currentUserProfile = null)
         }
     }
 
-    const UserModel = Post.db.model('User');
-    const me = userId
-        ? await UserModel.findById(userId, 'following followers').lean()
-        : null;
-
-    const userFollowing = me?.following || [];
-    const userFollowers = me?.followers || [];
-
     return items.map(item => {
         const idStr = item._id.toString();
         const likedByUsers = likedByUsersMap.get(idStr) || [];
-        const preview = getLikedByPreview(likedByUsers, userId ? userId.toString() : null, userFollowing, userFollowers);
+        const preview = getLikedByPreview(likedByUsers, userId ? userId.toString() : null);
         return {
             ...item,
             engagement: {
@@ -472,11 +473,7 @@ export async function stitchEngagement(userId, items, currentUserProfile = null)
             },
             isLikedBy: userId ? likedSet.has(idStr) : false,
             likedBy: likedByUsers,
-            likedByPreview: preview.likedByText ? {
-                text: preview.likedByText,
-                previewUser: preview.previewUser,
-                othersCount: preview.othersCount,
-            } : null,
+            likedByPreview: preview.likedByText ? { text: preview.likedByText } : null,
         };
     });
 }
@@ -487,16 +484,27 @@ export async function stitchEngagement(userId, items, currentUserProfile = null)
 
 /**
  * Call this when a user likes a post.
- * Atomically via Lua: sets like status in user's Hash, marks dirty, increments
- * like count (if key exists), and HSET user profile into the likedBy Hash.
+ * Atomically via Lua: initialises count key from DB (SET NX) so it always
+ * exists before INCR, adds postId to user liked Set, HSET user profile into
+ * the likedBy Hash.
  *
- * @param {*} userId
- * @param {*} postId
- * @param {{ username: string, fullName: string, profileImageUrl: string }} userProfile
+ * Returns { ok: boolean, count: number|null }
  */
 export async function onPostLiked(userId, postId, userProfile = {}) {
     const userIdStr = userId.toString();
     const postIdStr = postId.toString();
+    const countKey  = RedisKeys.postLikesCount(postIdStr);
+
+    // Use existing Redis value if present; seed from DB only on a cache miss so
+    // we avoid a DB round-trip on every hot like.
+    let seedCount = 0;
+    const existing = await redisClient.get(countKey).catch(() => null);
+    if (existing === null) {
+        const doc = await Post.findById(postId).select('engagement.likes').lean();
+        seedCount = doc?.engagement?.likes ?? 0;
+    } else {
+        seedCount = parseInt(existing, 10);
+    }
 
     const userData = JSON.stringify({
         _id: userIdStr,
@@ -510,7 +518,7 @@ export async function onPostLiked(userId, postId, userProfile = {}) {
     const runLiked = () => redisClient.eval(
         LIKE_LUA,
         3,
-        RedisKeys.postLikesCount(postIdStr),
+        countKey,
         RedisKeys.userLikedSet(userIdStr),
         RedisKeys.postLikedBy(postIdStr),
         postIdStr,
@@ -518,61 +526,76 @@ export async function onPostLiked(userId, postId, userProfile = {}) {
         userData,
         String(ENGAGEMENT_TTL),
         String(LIKE_STATUS_TTL),
+        String(seedCount),
     );
 
     try {
-        await runLiked();
-        return true;
+        const newCount = await runLiked();
+        return { ok: true, count: Number(newCount) };
     } catch (err) {
         if (err.message.includes('WRONGTYPE')) {
-            // Stale Hash key from old code — delete it and retry once
             await redisClient.del(RedisKeys.userLikedSet(userIdStr)).catch(() => {});
-            try { await runLiked(); return true; } catch {}
+            try {
+                const newCount = await runLiked();
+                return { ok: true, count: Number(newCount) };
+            } catch {}
         }
         console.error('[PostEngagement] onPostLiked error:', err.message);
-        return false;
+        return { ok: false, count: null };
     }
 }
 
 /**
  * Call this when a user unlikes a post.
- * Atomically via Lua: sets like status to '0', marks dirty, decrements like count
- * (floor 0), and HDEL the user from the likedBy Hash.
- * Also deletes the Like document from DB immediately (so the DB fallback in
- * batchIsLikedByUser is always accurate for unlikes).
+ * Atomically via Lua: initialises count key from DB (SET NX), DECRs (floor 0),
+ * SREMs postId from user liked Set, HDELs user from likedBy Hash.
+ * Also immediately deletes the Like document from DB so the DB fallback stays
+ * accurate.
+ *
+ * Returns { ok: boolean, count: number|null }
  */
 export async function onPostUnliked(userId, postId) {
     const userIdStr = userId.toString();
     const postIdStr = postId.toString();
+    const countKey  = RedisKeys.postLikesCount(postIdStr);
+
+    let seedCount = 0;
+    const existing = await redisClient.get(countKey).catch(() => null);
+    if (existing === null) {
+        const doc = await Post.findById(postId).select('engagement.likes').lean();
+        seedCount = doc?.engagement?.likes ?? 0;
+    } else {
+        seedCount = parseInt(existing, 10);
+    }
 
     const runUnliked = () => redisClient.eval(
         UNLIKE_LUA,
         3,
-        RedisKeys.postLikesCount(postIdStr),
+        countKey,
         RedisKeys.userLikedSet(userIdStr),
         RedisKeys.postLikedBy(postIdStr),
         postIdStr,
         userIdStr,
         String(ENGAGEMENT_TTL),
         String(LIKE_STATUS_TTL),
+        String(seedCount),
     );
 
     try {
-        await runUnliked();
+        const newCount = await runUnliked();
         await Like.deleteOne({ userId, postId }).catch(() => {});
-        return true;
+        return { ok: true, count: Number(newCount) };
     } catch (err) {
         if (err.message.includes('WRONGTYPE')) {
-            // Stale Hash key from old code — delete it and retry once
             await redisClient.del(RedisKeys.userLikedSet(userIdStr)).catch(() => {});
             try {
-                await runUnliked();
+                const newCount = await runUnliked();
                 await Like.deleteOne({ userId, postId }).catch(() => {});
-                return true;
+                return { ok: true, count: Number(newCount) };
             } catch {}
         }
         console.error('[PostEngagement] onPostUnliked error:', err.message);
-        return false;
+        return { ok: false, count: null };
     }
 }
 


### PR DESCRIPTION
- remove the db call for following and follow data which is not used for the the fetch post related api.
- add the cache check and fallback to db for isUserLiked the post,
- Add atomicity while updating like count, likedByUserList , {userId}- likesPostId (hash set)