### PR TITLE
feat: handle share limit of post as it re-orders search based on likes and shares and background sync to db

### DIFF
--- a/src/config/redis.config.js
+++ b/src/config/redis.config.js
@@ -190,6 +190,7 @@ export const RedisKeys = {
     // Post engagement counters
     postLikesCount: (postId) => `fn:post:${postId}:likes:count`,
     postCommentsCount: (postId) => `fn:post:${postId}:comments:count`,
+    postShareCount: (postId) => `fn:post:${postId}:shares:count`,
 
     // Universal default search page (no query — browse mode)
     defaultResults: () => 'fn:default:results',
@@ -200,11 +201,16 @@ export const RedisKeys = {
     postLikedBy: (postId) => `fn:post:${postId}:likedby`,
 
     userLikedSet: (userId) => `fn:user:${userId}:liked`,
-
     // Real-time features
     chatMessages: (chatId, page = 1) => `fn:chat:${chatId}:messages:p${page}`,
     onlineUsers: () => 'fn:live:online_users',
     tempUpload: (userId) => `fn:temp:upload:${userId}`,
+
+    // IP-based share rate limit: max 5 shares per IP per postId per day
+    shareIpLimit: (ip, postId) => {
+        const date = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+        return `fn:share:ip:${ip}:${postId}:${date}`;
+    },
 };
 
 export const RedisTTL = {
@@ -232,7 +238,8 @@ export const RedisTTL = {
     
     // Follow counters (long-lived, updated in-place on follow/unfollow)
     FOLLOW_COUNT: 7 * 24 * 60 * 60,  // 7 days
-
+    //  store the share count for post to avoid expensive recounting on every feed request and  reordering of the feed based on share count.
+    SHARE_COUNT: 7 * 24 * 60 * 60,   // 7 days
     // Followers/following LISTs (top-15 newest IDs, rebuilt by cron or on expiry)
     FOLLOW_LIST: 12 * 24 * 60 * 60,  // 12 days
 
@@ -249,6 +256,9 @@ export const RedisTTL = {
     // Temporary data
     TEMP_UPLOAD: 10 * 60,            // 10 minutes
     PASSWORD_RESET: 15 * 60,         // 15 minutes
+
+    // IP-based share rate-limit window
+    SHARE_IP_LIMIT: 24 * 60 * 60,   // 24 hours
 };
 
 export default redisClient;

--- a/src/controllers/explore.controllers.js
+++ b/src/controllers/explore.controllers.js
@@ -9,7 +9,7 @@ import { getViewableUserIds } from "../middlewares/privacy.middleware.js";
 import { enrichWithRatings } from "../utils/reviewUtils.js";
 import { addBadgesToNestedUsers, addBadgesToUsers } from "../utils/userBadge.utils.js";
 import { filterBusinessPostsByPaymentPlan } from "../utils/businessPlan.utils.js";
-import { batchIsLikedByUser, batchGetLikedByUsers, batchGetLikesCount } from "../utils/postEngagement.utils.js";
+import { batchIsLikedByUser, batchGetLikedByUsers, batchGetLikesCount,batchSharedCount } from "../utils/postEngagement.utils.js";
 import mongoose from "mongoose";
 
 export const getExploreFeed = asyncHandler(async (req, res) => {
@@ -335,10 +335,11 @@ export const getExploreFeed = asyncHandler(async (req, res) => {
     const currentUserId = req.user?._id ?? null;
     const feedIds = feed.map(item => item._id).filter(Boolean);
     if (feedIds.length) {
-        const [likedSet, likedByMap, likeCountMap] = await Promise.all([
+        const [likedSet, likedByMap, likeCountMap, sharedCountMap] = await Promise.all([
             currentUserId ? batchIsLikedByUser(currentUserId, feedIds) : Promise.resolve(new Set()),
             batchGetLikedByUsers(feedIds),
             batchGetLikesCount(feed),
+            batchSharedCount(feed)
         ]);
         feed = feed.map(item => {
             const idStr = item._id?.toString();
@@ -348,6 +349,7 @@ export const getExploreFeed = asyncHandler(async (req, res) => {
                 engagement: {
                     ...item.engagement,
                     likes: likeCountMap.get(idStr) ?? item.engagement?.likes ?? 0,
+                    shares: sharedCountMap.get(idStr) ?? item.engagement?.shares ?? 0
                 },
                 isLikedBy: currentUserId ? likedSet.has(idStr) : false,
                 likedBy: likedByMap.get(idStr) || [],

--- a/src/controllers/homeFeed.controllers.js
+++ b/src/controllers/homeFeed.controllers.js
@@ -15,7 +15,7 @@ import mongoose from 'mongoose';
 import { enrichWithRatings } from '../utils/reviewUtils.js';
 import { addBadgesToNestedUsers } from '../utils/userBadge.utils.js';
 import { getLikedByPreview } from '../utils/likedByPreview.utils.js';
-import { batchIsLikedByUser, batchGetLikedByUsers, batchGetLikesCount } from '../utils/postEngagement.utils.js';
+import { batchIsLikedByUser, batchGetLikedByUsers, batchGetLikesCount,batchSharedCount} from '../utils/postEngagement.utils.js';
 
 /**
  * ✅ HOME FEED - DATE SORTED WITH PAID BUSINESS PRIORITY
@@ -56,10 +56,11 @@ export const getHomeFeed = asyncHandler(async (req, res) => {
             if (cached?.data?.feed?.length) {
                 const cachedPosts = cached.data.feed;
                 const cachedPostIds = cachedPosts.map(p => p._id);
-                const [likedSet, likeCountMap, likedByUsersMap] = await Promise.all([
+                const [likedSet, likeCountMap, likedByUsersMap, sharedCountMap] = await Promise.all([
                     userId ? batchIsLikedByUser(userId, cachedPostIds) : Promise.resolve(new Set()),
                     batchGetLikesCount(cachedPosts),
                     batchGetLikedByUsers(cachedPostIds),
+                    batchSharedCount(cachedPosts)
                 ]);
 
                 cached.data.feed = cachedPosts.map(post => {
@@ -71,6 +72,7 @@ export const getHomeFeed = asyncHandler(async (req, res) => {
                         engagement: {
                             ...post.engagement,
                             likes: likeCountMap.get(idStr) ?? post.engagement?.likes ?? 0,
+                            shares: sharedCountMap.get(idStr) ?? post.engagement?.shares ?? 0
                         },
                         isLikedBy: likedSet.has(idStr),
                         likedBy: likedByUsers,
@@ -282,10 +284,11 @@ export const getHomeFeed = asyncHandler(async (req, res) => {
 
         // ✅ 3. Get user like status + likedBy from Redis (Hash-based)
         const postIds = posts.map(post => post._id);
-        const [likedPostIds, likesByPost, likeCountMap] = await Promise.all([
+        const [likedPostIds, likesByPost, likeCountMap, sharedCountMap] = await Promise.all([
             userId ? batchIsLikedByUser(userId, postIds) : Promise.resolve(new Set()),
             batchGetLikedByUsers(postIds),
             batchGetLikesCount(posts),
+            batchSharedCount(posts)
         ]);
 
         // ✅ 4. Get top comments efficiently (no nested queries)
@@ -335,6 +338,7 @@ export const getHomeFeed = asyncHandler(async (req, res) => {
                 engagement: {
                     ...post.engagement,
                     likes: likeCountMap.get(postIdStr) ?? post.engagement?.likes ?? 0,
+                    shares: sharedCountMap.get(postIdStr) ?? post.engagement?.shares ?? 0
                 },
                 comments: commentsByPost.get(postIdStr) || [],
                 isLikedBy: likedPostIds.has(postIdStr),

--- a/src/controllers/reel.controllers.js
+++ b/src/controllers/reel.controllers.js
@@ -8,7 +8,7 @@ import { enrichWithRatings } from "../utils/reviewUtils.js";
 import { addBadgesToNestedUsers } from "../utils/userBadge.utils.js";
 import { getLikedByPreview } from "../utils/likedByPreview.utils.js";
 import Like from "../models/like.models.js";
-import { batchIsLikedByUser, batchGetLikedByUsers, batchGetLikesCount, batchGetCommentsCount } from "../utils/postEngagement.utils.js";
+import { batchIsLikedByUser, batchGetLikedByUsers, batchGetLikesCount, batchGetCommentsCount, batchSharedCount } from "../utils/postEngagement.utils.js";
 import mongoose from "mongoose";
 import { getFollowStatus } from "../utils/followEngagement.utils.js";
 
@@ -167,11 +167,12 @@ export const getSuggestedReels = asyncHandler(async (req, res) => {
             const cachedData = cache.reels.data;
             if (currentUserId && cachedData.reels?.length) {
                 const reelIds = cachedData.reels.map(r => r._id);
-                const [likedSet, likeCountMap, commentCountMap, likedByUsersMap] = await Promise.all([
+                const [likedSet, likeCountMap, commentCountMap, likedByUsersMap, sharedCountMap] = await Promise.all([
                     batchIsLikedByUser(currentUserId, reelIds),
                     batchGetLikesCount(cachedData.reels),
                     batchGetCommentsCount(cachedData.reels),
                     batchGetLikedByUsers(reelIds),
+                    batchSharedCount(cachedData.reels)
                 ]);
                 const userIdStr = currentUserId.toString();
                 const updatedReels = cachedData.reels.map(r => {
@@ -184,7 +185,7 @@ export const getSuggestedReels = asyncHandler(async (req, res) => {
                     const preview = getLikedByPreview(likedByUsers, currentUserId);
                     return {
                         ...r,
-                        engagement: { ...(r.engagement || {}), likes: likeCountMap.get(rid) ?? r.engagement?.likes ?? 0, comments: commentCountMap.get(rid) ?? r.engagement?.comments ?? 0 },
+                        engagement: { ...(r.engagement || {}), likes: likeCountMap.get(rid) ?? r.engagement?.likes ?? 0, comments: commentCountMap.get(rid) ?? r.engagement?.comments ?? 0, shares: sharedCountMap.get(rid) ?? r.engagement?.shares ?? 0 },
                         isLikedBy: likedSet.has(rid),
                         likedBy: likedByUsers,
                         likedByPreview: preview.likedByText ? { text: preview.likedByText } : null,
@@ -396,10 +397,12 @@ export const getSuggestedReels = asyncHandler(async (req, res) => {
 
             // Get likedBy from Redis Hash (max 20 per reel) + isLikedBy status
             const reelIds = reels.map(reel => reel._id);
-            const [likedReelSet, likesByReel, reelLikeCountMap] = await Promise.all([
+            const [likedReelSet, likesByReel, reelLikeCountMap, commentCountMap, sharedCountMap] = await Promise.all([
                 currentUserId ? batchIsLikedByUser(currentUserId, reelIds) : Promise.resolve(new Set()),
                 batchGetLikedByUsers(reelIds),
                 batchGetLikesCount(reels),
+                batchGetCommentsCount(reels),
+                batchSharedCount(reels)
             ]);
 
             // Inject current user into likedBy if their like is deferred
@@ -422,6 +425,8 @@ export const getSuggestedReels = asyncHandler(async (req, res) => {
                     engagement: {
                         ...reel.engagement,
                         likes: reelLikeCountMap.get(reelIdStr) ?? reel.engagement?.likes ?? 0,
+                        comments: commentCountMap.get(reelIdStr) ?? reel.engagement?.comments ?? 0,
+                        shares: sharedCountMap.get(reelIdStr) ?? reel.engagement?.shares ?? 0,
                     },
                     isLikedBy: likedReelSet.has(reelIdStr),
                     likedBy: likedByUsers,

--- a/src/controllers/searchAllContent.controllers.js
+++ b/src/controllers/searchAllContent.controllers.js
@@ -8,7 +8,7 @@ import { ApiError } from '../utils/ApiError.js';
 import { getCoordinates } from '../utils/getCoordinates.js';
 import { filterBusinessPostsByPaymentPlan } from '../utils/businessPlan.utils.js';
 import { addBadgesToNestedUsers, addBadgesToUsers } from '../utils/userBadge.utils.js';
-import { batchIsLikedByUser, batchGetLikedByUsers, batchGetLikesCount } from '../utils/postEngagement.utils.js';
+import { batchIsLikedByUser, batchGetLikedByUsers, batchGetLikesCount,batchSharedCount } from '../utils/postEngagement.utils.js';
 import { getLikedByPreview } from '../utils/likedByPreview.utils.js';
 
 export const searchAllContent = async (req, res) => {
@@ -512,10 +512,11 @@ export const searchAllContent = async (req, res) => {
         // Stitch isLikedBy + likedBy (max 20 from Redis Hash) into search results
         const currentUserId = req.user?._id?.toString() ?? null;
         const contentIds = paginatedContent.map(item => item._id);
-        const [likedSet, likedByMap, searchLikeCountMap] = await Promise.all([
+        const [likedSet, likedByMap, searchLikeCountMap, sharedCountMap] = await Promise.all([
             currentUserId ? batchIsLikedByUser(req.user._id, contentIds) : Promise.resolve(new Set()),
             batchGetLikedByUsers(contentIds),
             batchGetLikesCount(paginatedContent),
+            batchSharedCount(paginatedContent)
         ]);
 
         const stitchedContent = paginatedContent.map(item => {
@@ -527,6 +528,8 @@ export const searchAllContent = async (req, res) => {
                 engagement: {
                     ...item.engagement,
                     likes: searchLikeCountMap.get(idStr) ?? item.engagement?.likes ?? 0,
+                    shares: sharedCountMap.get(idStr) ?? item.engagement?.shares ?? 0
+
                 },
                 isLikedBy: likedSet.has(idStr),
                 likedBy: likedByUsers,

--- a/src/controllers/share.controllers.js
+++ b/src/controllers/share.controllers.js
@@ -13,7 +13,7 @@ import {
   sanitizePostForGuest,
   generateErrorHTML,
 } from "../utils/shareUtils.js";
-import { redisClient } from "../config/redis.config.js";
+import { redisClient, RedisKeys, RedisTTL } from "../config/redis.config.js";
 import { batchIsLikedByUser } from "../utils/postEngagement.utils.js";
 
 /**
@@ -534,6 +534,17 @@ export const trackShare = asyncHandler(async (req, res) => {
     throw new ApiError(400, "Invalid post ID");
   }
 
+  // IP-based rate limit: max 5 shares per IP per postId per day
+  const ip = req.ip || req.headers['x-forwarded-for']?.split(',')[0]?.trim() || 'unknown';
+  const ipLimitKey = RedisKeys.shareIpLimit(ip, postId);
+  const ipShareCount = await redisClient.incr(ipLimitKey);
+  if (ipShareCount === 1) {
+    await redisClient.expire(ipLimitKey, RedisTTL.SHARE_IP_LIMIT);
+  }
+  if (ipShareCount > 5) {
+    throw new ApiError(429, "Share limit reached. You can share this post up to 5 times per day.");
+  }
+
   // Find post
   const post = await Post.findById(postId);
 
@@ -546,11 +557,26 @@ export const trackShare = asyncHandler(async (req, res) => {
   if (!shareCheck.canShare) {
     throw new ApiError(403, shareCheck.reason);
   }
+  let shareCount;
+  try {
+    const results = await redisClient
+      .multi()
+      .incr(RedisKeys.postShareCount(postId))
+      .expire(RedisKeys.postShareCount(postId), RedisTTL.SHARE_COUNT)
+      .exec();
+    shareCount = results?.[0] ?? null;
+  } catch (_) {
+    
+  }
 
-  // Increment engagement counter
-  await Post.findByIdAndUpdate(postId, {
-    $inc: { "engagement.shares": 1 },
-  });
+  if (shareCount == null) {
+    const updated = await Post.findByIdAndUpdate(
+      postId,
+      { $inc: { "engagement.shares": 1 } },
+      { new: true }
+    ).select("engagement.shares");
+    shareCount = updated?.engagement?.shares ?? 0;
+  }
 
   // Create PostInteraction record
   await PostInteraction.create({
@@ -574,16 +600,13 @@ export const trackShare = asyncHandler(async (req, res) => {
               userAgent: req.get("user-agent"),
             },
           ],
-          $slice: -100, // Keep only last 100 share events
+          $slice: -100,
         },
       },
     });
   }
 
-  // Get updated share count
-  const updatedPost = await Post.findById(postId).select("engagement.shares");
-
-  // Invalidate cache
+  // Invalidate share-page cache
   await redisClient.del(`fn:share:post:${postId}`);
   await redisClient.del(`fn:share:reel:${postId}`);
 
@@ -591,7 +614,7 @@ export const trackShare = asyncHandler(async (req, res) => {
     new ApiResponse(
       200,
       {
-        shareCount: updatedPost.engagement.shares,
+        shareCount,
         shareUrl: `https://findernate.com/${post.postType === "reel" || post.postType === "video" ? "r" : "p"}/${postId}`,
       },
       "Share tracked successfully"

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import http from 'http';
 import socketManager from './config/socket.js';
 import './config/firebase-admin.config.js'; // Initialize Firebase Admin on startup
 import { startSubscriptionExpiryJob } from './jobs/subscriptionExpiry.job.js';
+import { startShareSyncJob } from './jobs/shareSync.job.js';
 import { startLikeWorker } from './queues/likeQueue.js';
 // import { seedLikesToRedis } from './scripts/seedLikesToRedis.js';
 import { redisClient } from './config/redis.config.js';
@@ -61,6 +62,7 @@ connectDB()
 
             // Start cron jobs and queue workers
             startSubscriptionExpiryJob();
+            startShareSyncJob();
             startLikeWorker();
         });
 

--- a/src/jobs/shareSync.job.js
+++ b/src/jobs/shareSync.job.js
@@ -1,0 +1,68 @@
+import cron from 'node-cron';
+import Post from '../models/userPost.models.js';
+import { redisClient, RedisKeys } from '../config/redis.config.js';
+
+
+export const syncShareCountsToDB = async () => {
+    let synced = 0;
+    let failed = 0;
+    let cursor = '0';
+
+    try {
+        do {
+            const [nextCursor, keys] = await redisClient.scan(
+                cursor,
+                'MATCH', 'fn:post:*:shares:count',
+                'COUNT', 100
+            );
+            cursor = nextCursor;
+
+            if (keys.length === 0) continue;
+
+            const values = await redisClient.mget(...keys);
+
+            const ops = [];
+            for (let i = 0; i < keys.length; i++) {
+                const count = parseInt(values[i], 10);
+                if (isNaN(count) || count <= 0) continue;
+
+                // fn:post:<postId>:shares:count  →  extract postId
+                const postId = keys[i].split(':')[2];
+                ops.push(
+                    Post.findByIdAndUpdate(postId, {
+                        $set: { 'engagement.shares': count },
+                    }).catch((err) => {
+                        console.error(` [ShareSync] Failed to update post ${postId}:`, err.message);
+                        failed++;
+                    })
+                );
+            }
+
+            const results = await Promise.allSettled(ops);
+            synced += results.filter((r) => r.status === 'fulfilled' && r.value).length;
+
+        } while (cursor !== '0');
+
+        return { synced, failed };
+    } catch (err) {
+        return { synced, failed, error: err.message };
+    }
+};
+
+/**
+ * Start share-sync cron jobs:
+ *  - Every day at 12AM →  full authoritative flush at midnight
+ */
+export const startShareSyncJob = () => {
+
+    // Every day at 12:00 AM (midnight)
+    cron.schedule('0 0 * * *', async () => {
+        console.log('[Cron] Share sync (midnight) triggered');
+        await syncShareCountsToDB();
+    }, {
+        scheduled: true,
+        timezone: 'Asia/Kolkata',
+    });
+
+    console.log('[Cron] Share sync job scheduled (daily midnight IST)');
+};

--- a/src/utils/cacheWarmer.utils.js
+++ b/src/utils/cacheWarmer.utils.js
@@ -13,6 +13,7 @@ import Like from '../models/like.models.js';
 import Comment from '../models/comment.models.js';
 import Follower from '../models/follower.models.js';
 import { User } from '../models/user.models.js';
+import Post from '../models/userPost.models.js';
 
 const ENGAGEMENT_TTL  = RedisTTL.POST_ENGAGEMENT;
 const LIKE_STATUS_TTL = RedisTTL.POST_LIKE_STATUS;
@@ -22,6 +23,7 @@ const STATUS_TTL      = RedisTTL.FOLLOW_STATUS;
 const MAX_LIKEDBY     = 50;
 const DB = parseInt(process.env.REDIS_DB) || 0;
 
+const SHARES_COUNT_RE   = /^fn:post:([^:]+):shares:count$/;
 const LIKES_COUNT_RE    = /^fn:post:([^:]+):likes:count$/;
 const COMMENTS_COUNT_RE = /^fn:post:([^:]+):comments:count$/;
 const USER_LIKED_RE     = /^fn:user:([^:]+):liked$/;
@@ -31,6 +33,26 @@ const FOLLOWING_ZSET_RE = /^fn:user:([^:]+):following$/;
 const FOLLOWERS_CNT_RE  = /^fn:user:([^:]+):followers:count$/;
 const FOLLOWING_CNT_RE  = /^fn:user:([^:]+):following:count$/;
 const FOLLOW_STATUS_RE  = /^fn:user:([^:]+):following:status$/;
+
+async function reseedShareCount(postId) {
+    const key = RedisKeys.postShareCount(postId);
+
+    const exists = await redisClient.exists(key);
+    if (exists) {
+        console.log(`[CacheWarmer] shares:count already present, skipping reseed post=${postId}`);
+        return;
+    }
+
+    const post = await Post.findById(postId).select('engagement.shares').lean();
+    const count = post?.engagement?.shares ?? 0;
+
+    const set = await redisClient.set(key, count, 'EX', RedisTTL.SHARE_COUNT, 'NX');
+    if (set) {
+        console.log(`shares:count re-seeded post=${postId} count=${count}`);
+    } else {
+        console.log(`hares:count refreshed concurrently, skipping post=${postId}`);
+    }
+}
 
 async function reseedLikeCount(postId) {
     const key = RedisKeys.postLikesCount(postId);
@@ -314,6 +336,14 @@ export function startCacheWarmer() {
     });
 
     subscriber.on('pmessage', (_pattern, _channel, key) => {
+        const sharesMatch = SHARES_COUNT_RE.exec(key);
+        if (sharesMatch) {
+            reseedShareCount(sharesMatch[1]).catch(err =>
+                console.error(`[CacheWarmer] reseedShareCount error key=${key}:`, err.message)
+            );
+            return;
+        }
+
         const likesMatch = LIKES_COUNT_RE.exec(key);
         if (likesMatch) {
             reseedLikeCount(likesMatch[1]).catch(err =>

--- a/src/utils/postEngagement.utils.js
+++ b/src/utils/postEngagement.utils.js
@@ -629,3 +629,55 @@ export async function onCommentDeleted(postId) {
         console.error('[PostEngagement] onCommentDeleted error:', err.message);
     }
 }
+
+export async function batchSharedCount(items) {
+    if (!items || !items.length) return new Map();
+    const seen = new Set();
+    const unique = items.filter(i => {
+        const id = (i._id ?? i).toString();
+        return seen.has(id) ? false : seen.add(id);
+    });
+    const idStrs = unique.map(i => (i._id ?? i).toString());
+
+    try {
+        const keys = idStrs.map(id => RedisKeys.postShareCount(id));
+        const values = await redisClient.mget(...keys);
+
+        const counts = new Map();
+        const missedIds = [];
+        const missedItems = [];
+
+        values.forEach((val, i) => {
+            if (val !== null) {
+                counts.set(idStrs[i], parseInt(val, 10));
+            } else {
+                missedIds.push(idStrs[i]);
+                missedItems.push(unique[i]);
+            }
+        });
+
+        if (missedIds.length) {
+            const missedOids = missedIds.map(id => new mongoose.Types.ObjectId(id));
+            const dbPosts = await Post.find({ _id: { $in: missedOids } }).select('engagement.shares').lean();
+            const dbMap = new Map(dbPosts.map(p => [p._id.toString(), p.engagement?.shares ?? 0]));
+
+            const pipeline = redisClient.pipeline();
+            missedIds.forEach((id, i) => {
+                const count = dbMap.get(id) ?? (missedItems[i]?.engagement?.shares ?? 0);
+                counts.set(id, count);
+                pipeline.set(RedisKeys.postShareCount(id), count, 'EX', RedisTTL.SHARE_COUNT);
+            });
+            await pipeline.exec();
+        }
+
+        return counts;
+    } catch (err) {
+        console.error('[PostEngagement] batchSharedCount error:', err.message);
+        const counts = new Map();
+        unique.forEach(item => {
+            const id = (item._id ?? item).toString();
+            counts.set(id, item?.engagement?.shares ?? 0);
+        });
+        return counts;
+    }
+}


### PR DESCRIPTION
- add ip based tracking for post share and max 5 for each post per user with 24 hours
- handle search reorder as it depends on share and like sync the count to db eventually to handle sudden reorder of the search